### PR TITLE
feat: add profile-auth gateway mode

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -362,6 +362,32 @@ curl http://127.0.0.1:4000/v1/responses \
   -d '{"model":"prodex-fast","input":"hello"}'
 ```
 
+For generic OpenAI-compatible clients that should use Prodex's saved OpenAI/Codex profiles instead of an upstream API key, start the gateway explicitly in profile-backed mode:
+
+```bash
+unset OPENAI_API_KEY
+PRODEX_GATEWAY_TOKEN=local-client-token \
+  prodex gateway --profile-auth --listen 127.0.0.1:4100
+```
+
+Configure the client with `base_url` / `baseURL` set to `http://127.0.0.1:4100/v1` and a local bearer token only if the gateway was started with one:
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://127.0.0.1:4100/v1",
+  apiKey: process.env.PRODEX_GATEWAY_TOKEN ?? "local-dev-token",
+});
+
+await client.responses.create({
+  model: "gpt-5.5",
+  input: "hello from a generic client",
+});
+```
+
+Profile-backed gateway mode is limited to `/v1/responses`; local client auth is only a caller-auth check and never affects upstream profile choice.
+
 The gateway serves `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/images/*`, `/v1/audio/*`, `/v1/batches`, `/v1/rerank`, `/v1/a2a`, `/v1/messages`, and `/v1/models` where the selected upstream supports them. It emits `x-prodex-call-id`, writes `gateway_spend` events for request and response phases to runtime logs, can export those events to JSONL or HTTP using generic, OTel, Datadog, or Langfuse-shaped payloads, and supports catalog-backed route strategies (`fallback`, `round-robin`, `least-busy`, `lowest-cost`, `lowest-latency`, `rpm`, `tpm`, `first`), static virtual keys with persisted request/spend usage and model/budget/RPM/TPM limits, file, SQLite, Postgres, or Redis-backed gateway admin/usage/ledger/SCIM state, plus keyword/model, Presidio, and external webhook guardrails. Admin-token, trusted-proxy SSO, or OIDC/JWT bearer requests can inspect usage, create generated-token keys, rotate/disable/update/delete admin-managed keys, provision SSO users through SCIM-compatible `/v1/prodex/gateway/scim/v2/Users`, read virtual-key usage at `/v1/prodex/gateway/keys` and `/v1/prodex/gateway/usage`, read recent billing ledger records with response-status/output-token reconciliation at `/v1/prodex/gateway/ledger`, read aggregated billing totals at `/v1/prodex/gateway/ledger/summary`, export billing CSV from `/v1/prodex/gateway/ledger.csv` and `/v1/prodex/gateway/ledger/summary.csv`, scrape Prometheus text metrics at `/v1/prodex/gateway/metrics`, fetch the machine-readable gateway contract at `/v1/prodex/gateway/openapi.json`, and open the built-in gateway admin dashboard at `/v1/prodex/gateway/admin`; policy/env-backed keys remain read-only, admin-managed key and SCIM user mutations are recorded in `prodex audit`, and additional admin-plane tokens can be `admin` or read-only `viewer` with optional virtual-key prefix and tenant scopes.
 
 JavaScript clients can use `@christiandoxa/prodex-gateway-sdk` for gateway Responses, key, usage, billing ledger, metrics, and OpenAPI calls.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ curl http://127.0.0.1:4000/v1/responses \
   -d '{"model":"prodex-fast","input":"hello"}'
 ```
 
+Profile-backed OpenAI Responses mode is explicit and does not require `OPENAI_API_KEY`:
+
+```bash
+unset OPENAI_API_KEY
+PRODEX_GATEWAY_TOKEN=local-client-token \
+  prodex gateway --profile-auth --listen 127.0.0.1:4100
+```
+
+Point any OpenAI-compatible Responses client at the local `/v1` base URL. The inbound bearer token only authenticates the local caller when configured; it never selects or influences the upstream Prodex profile.
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://127.0.0.1:4100/v1",
+  apiKey: process.env.PRODEX_GATEWAY_TOKEN ?? "local-dev-token",
+});
+
+const response = await client.responses.create({
+  model: "gpt-5.5",
+  input: "hello from a generic client",
+});
+console.log(response.output_text);
+```
+
+`--profile-auth` is scoped to `/v1/responses`. Prodex chooses and pins one eligible profile before the request or stream is committed, preserves existing Responses/session affinity for continuations, may rotate only on eligible pre-commit auth/quota/rate failures, and never rotates mid-stream.
+
 </details>
 
 <details>

--- a/crates/prodex-app/src/app_commands/runtime_launch/gateway_config.rs
+++ b/crates/prodex-app/src/app_commands/runtime_launch/gateway_config.rs
@@ -28,7 +28,34 @@ pub(super) fn resolve_gateway_launch_config(
     let provider = args
         .provider
         .or_else(|| policy.provider.as_deref().and_then(gateway_policy_provider));
-    let provider_options = gateway_provider_options(provider, args.api_key.as_deref())?;
+    if args.profile_auth && provider.is_some() {
+        bail!(
+            "gateway --profile-auth is only supported for the default OpenAI-compatible provider"
+        );
+    }
+    if args.profile_auth
+        && args
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+    {
+        bail!("gateway --profile-auth and --api-key are mutually exclusive");
+    }
+    if args.profile_auth
+        && (env::var("OPENAI_API_KEY")
+            .ok()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+            || env::var("OPENAI_API_KEYS")
+                .ok()
+                .and_then(|value| gateway_api_keys_from_list(&value))
+                .is_some())
+    {
+        bail!("gateway --profile-auth and OPENAI_API_KEY(S) are mutually exclusive startup modes");
+    }
+    let provider_options =
+        gateway_provider_options(provider, args.api_key.as_deref(), args.profile_auth)?;
     let auth_token = args
         .auth_token
         .as_deref()
@@ -155,7 +182,7 @@ pub(super) fn resolve_gateway_launch_config(
 
     Ok(ResolvedGatewayLaunchConfig {
         provider_name: provider.map(SuperExternalProvider::as_str),
-        upstream_base_url: gateway_upstream_base_url(args, policy, provider)?,
+        upstream_base_url: gateway_upstream_base_url(args, policy, provider, args.profile_auth)?,
         provider_options,
         auth_token_hash: auth_token
             .as_deref()
@@ -641,6 +668,7 @@ fn gateway_upstream_base_url(
     args: &GatewayArgs,
     policy: &prodex_runtime_policy::RuntimePolicyGatewaySettings,
     provider: Option<SuperExternalProvider>,
+    profile_auth: bool,
 ) -> Result<String> {
     let raw = args
         .base_url
@@ -656,6 +684,7 @@ fn gateway_upstream_base_url(
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
         })
+        .or_else(|| profile_auth.then(|| "https://chatgpt.com/backend-api".to_string()))
         .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
     gateway_normalize_upstream_base_url(&raw, provider)
 }
@@ -683,7 +712,11 @@ fn gateway_normalize_upstream_base_url(
 fn gateway_provider_options(
     provider: Option<SuperExternalProvider>,
     api_key: Option<&str>,
+    profile_auth: bool,
 ) -> Result<RuntimeLocalRewriteProviderOptions> {
+    if profile_auth {
+        return Ok(RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses);
+    }
     match provider {
         Some(SuperExternalProvider::Anthropic) => {
             runtime_anthropic_api_keys_from_request_or_env(api_key)

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite.rs
@@ -59,6 +59,7 @@ use super::provider_bridge::{
     runtime_provider_request_ledger_message,
 };
 use super::*;
+use crate::runtime_proxy::{proxy_runtime_responses_request, respond_runtime_responses_reply};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) const RUNTIME_LOCAL_REWRITE_PROXY_MOUNT_PATH: &str = "/v1";
@@ -165,6 +166,18 @@ pub(crate) fn start_runtime_local_rewrite_proxy(
             .build()
             .context("failed to build runtime local rewrite async runtime")?,
     );
+    let profile_auth_enabled = matches!(
+        &provider,
+        RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses
+    );
+    let runtime_current_profile = runtime_local_rewrite_current_profile(&provider, state)?;
+    let persisted_usage_snapshots = if profile_auth_enabled {
+        load_runtime_usage_snapshots_with_recovery(paths, &state.profiles)
+            .map(|loaded| loaded.value)
+            .unwrap_or_default()
+    } else {
+        BTreeMap::new()
+    };
     let runtime_shared = RuntimeRotationProxyShared {
         upstream_no_proxy,
         async_client: build_runtime_upstream_async_http_client(true)?,
@@ -183,13 +196,21 @@ pub(crate) fn start_runtime_local_rewrite_proxy(
             state: state.clone(),
             upstream_base_url: upstream_base_url.clone(),
             include_code_review: false,
-            current_profile: RUNTIME_LOCAL_REWRITE_PROFILE.to_string(),
-            profile_usage_auth: BTreeMap::new(),
+            current_profile: runtime_current_profile,
+            profile_usage_auth: if profile_auth_enabled {
+                load_runtime_profile_usage_auth_cache(state)
+            } else {
+                BTreeMap::new()
+            },
             turn_state_bindings: BTreeMap::new(),
-            session_id_bindings: BTreeMap::new(),
+            session_id_bindings: if profile_auth_enabled {
+                state.session_profile_bindings.clone()
+            } else {
+                BTreeMap::new()
+            },
             continuation_statuses: RuntimeContinuationStatuses::default(),
             profile_probe_cache: BTreeMap::new(),
-            profile_usage_snapshots: BTreeMap::new(),
+            profile_usage_snapshots: persisted_usage_snapshots,
             profile_retry_backoff_until: BTreeMap::new(),
             profile_transport_backoff_until: BTreeMap::new(),
             profile_route_circuit_open_until: BTreeMap::new(),
@@ -354,6 +375,33 @@ pub(crate) fn start_runtime_local_rewrite_proxy(
         active_request_count: Arc::clone(&runtime_shared.active_request_count),
         owner_lock: None,
     })
+}
+
+fn runtime_local_rewrite_current_profile(
+    provider: &RuntimeLocalRewriteProviderOptions,
+    state: &AppState,
+) -> Result<String> {
+    if !matches!(
+        provider,
+        RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses
+    ) {
+        return Ok(RUNTIME_LOCAL_REWRITE_PROFILE.to_string());
+    }
+    if let Some(active) = state.active_profile.as_deref()
+        && state
+            .profiles
+            .get(active)
+            .is_some_and(|profile| matches!(profile.provider, ProfileProvider::Openai))
+    {
+        return Ok(active.to_string());
+    }
+    state
+        .profiles
+        .iter()
+        .find_map(|(name, profile)| {
+            matches!(profile.provider, ProfileProvider::Openai).then(|| name.clone())
+        })
+        .context("gateway --profile-auth requires at least one OpenAI/Codex profile")
 }
 
 fn build_runtime_local_rewrite_http_client() -> Result<reqwest::blocking::Client> {
@@ -571,6 +619,57 @@ fn handle_runtime_local_rewrite_proxy_request(
         ));
         return;
     }
+    if matches!(
+        &shared.provider,
+        RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses
+    ) {
+        let (path, query) = match captured.path_and_query.split_once('?') {
+            Some((path, query)) => (path.to_string(), Some(query.to_string())),
+            None => (captured.path_and_query.clone(), None),
+        };
+        if path != "/v1/responses" {
+            let _ = request.respond(build_runtime_proxy_text_response(
+                404,
+                "gateway profile-auth mode only supports /v1/responses",
+            ));
+            return;
+        }
+        let mut runtime_request = captured;
+        runtime_request.path_and_query = match query {
+            Some(query) => format!(
+                "{}/responses?{}",
+                runtime_proxy_crate::RUNTIME_PROXY_OPENAI_MOUNT_PATH,
+                query
+            ),
+            None => format!(
+                "{}/responses",
+                runtime_proxy_crate::RUNTIME_PROXY_OPENAI_MOUNT_PATH
+            ),
+        };
+        let response =
+            match proxy_runtime_responses_request(request_id, &runtime_request, runtime_shared) {
+                Ok(response) => response,
+                Err(err) => {
+                    runtime_proxy_log(
+                        runtime_shared,
+                        runtime_proxy_structured_log_message(
+                            "profile_auth_gateway_responses_error",
+                            [
+                                runtime_proxy_log_field("request", request_id.to_string()),
+                                runtime_proxy_log_field("transport", "http"),
+                                runtime_proxy_log_field("error", format!("{err:#}")),
+                            ],
+                        ),
+                    );
+                    RuntimeResponsesReply::Buffered(build_runtime_proxy_text_response_parts(
+                        502,
+                        &err.to_string(),
+                    ))
+                }
+            };
+        respond_runtime_responses_reply(request, response);
+        return;
+    }
     let route_load = shared
         .gateway_route_load
         .lock()
@@ -613,6 +712,7 @@ fn handle_runtime_local_rewrite_proxy_request(
             RuntimeLocalRewriteProviderOptions::Anthropic { .. } => "Anthropic",
             RuntimeLocalRewriteProviderOptions::Copilot { .. } => "GitHub Copilot",
             RuntimeLocalRewriteProviderOptions::OpenAiResponses { .. } => "OpenAI",
+            RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses => "OpenAI profile auth",
             RuntimeLocalRewriteProviderOptions::LocalEmbeddingsOnly { .. } => {
                 "Prodex local embeddings"
             }

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_options.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_options.rs
@@ -16,6 +16,7 @@ pub(crate) enum RuntimeLocalRewriteProviderOptions {
     OpenAiResponses {
         api_keys: Vec<String>,
     },
+    ProfileAuthOpenAiResponses,
     LocalEmbeddingsOnly {
         embedding_model: String,
     },
@@ -39,6 +40,7 @@ impl RuntimeLocalRewriteProviderOptions {
                 RuntimeProviderBridgeKind::Copilot
             }
             RuntimeLocalRewriteProviderOptions::OpenAiResponses { .. }
+            | RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses
             | RuntimeLocalRewriteProviderOptions::LocalEmbeddingsOnly { .. } => {
                 RuntimeProviderBridgeKind::OpenAiResponses
             }

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests.rs
@@ -4,7 +4,8 @@ use super::local_rewrite::{
     RuntimeGatewayStateStore, RuntimeLocalRewriteProviderOptions,
     RuntimeLocalRewriteProxyStartOptions, start_runtime_local_rewrite_proxy,
 };
-use crate::AppState;
+use crate::{AppState, ProfileEntry, ProfileProvider, ResponseProfileBinding};
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 mod deepseek;
@@ -15,6 +16,7 @@ mod gateway_admin_tenant_scope;
 mod gateway_state;
 mod gateway_usage;
 mod model_memory;
+mod profile_auth;
 mod support;
 
 use support::*;
@@ -196,10 +198,148 @@ fn gateway_guardrail_pii_redaction_rewrites_request_before_upstream() {
         .body_rx
         .recv_timeout(Duration::from_secs(2))
         .expect("upstream should receive redacted request");
-    let upstream_body = String::from_utf8(upstream_body).expect("upstream body should be utf8");
+    let upstream_body =
+        String::from_utf8(upstream_body.body).expect("upstream body should be utf8");
     assert!(upstream_body.contains("<redacted>"));
     assert!(!upstream_body.contains("alice@example.com"));
     assert!(!upstream_body.contains("4111-1111-1111-1111"));
+}
+
+#[test]
+fn gateway_profile_auth_continuations_use_existing_response_and_session_affinity() {
+    let root = temp_root("gateway-profile-auth-continuation-affinity");
+    let paths = app_paths_for_root(root);
+    let upstream = TestUpstream::start_n(4);
+    let active_home = paths.managed_profiles_root.join("active");
+    let bound_home = paths.managed_profiles_root.join("bound");
+    write_openai_profile_auth_json(&active_home, "active-access-token", "active-account");
+    write_openai_profile_auth_json(&bound_home, "bound-access-token", "bound-account");
+    let bound_profile = ResponseProfileBinding {
+        profile_name: "bound".to_string(),
+        bound_at: 1,
+    };
+    let state = AppState {
+        active_profile: Some("active".to_string()),
+        profiles: BTreeMap::from([
+            (
+                "active".to_string(),
+                ProfileEntry {
+                    codex_home: active_home,
+                    managed: true,
+                    email: Some("active@example.test".to_string()),
+                    provider: ProfileProvider::Openai,
+                },
+            ),
+            (
+                "bound".to_string(),
+                ProfileEntry {
+                    codex_home: bound_home,
+                    managed: true,
+                    email: Some("bound@example.test".to_string()),
+                    provider: ProfileProvider::Openai,
+                },
+            ),
+        ]),
+        last_run_selected_at: BTreeMap::new(),
+        response_profile_bindings: BTreeMap::from([(
+            "resp_bound".to_string(),
+            bound_profile.clone(),
+        )]),
+        session_profile_bindings: BTreeMap::from([("session_bound".to_string(), bound_profile)]),
+    };
+    let now = chrono::Local::now().timestamp();
+    std::fs::write(
+        paths.root.join("runtime-usage-snapshots.json"),
+        serde_json::json!({
+            "bound": {
+                "checked_at": now,
+                "five_hour_status": "Ready",
+                "five_hour_remaining_percent": 100,
+                "five_hour_reset_at": now + 3600,
+                "weekly_status": "Ready",
+                "weekly_remaining_percent": 100,
+                "weekly_reset_at": now + 3600,
+            }
+        })
+        .to_string(),
+    )
+    .expect("usage snapshot fixture should be written");
+    let proxy = start_runtime_local_rewrite_proxy(RuntimeLocalRewriteProxyStartOptions {
+        paths: &paths,
+        state: &state,
+        upstream_base_url: format!("http://{}/backend-api", upstream.addr),
+        provider: RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses,
+        upstream_no_proxy: false,
+        smart_context_enabled: false,
+        presidio_redaction_enabled: false,
+        model_context_window_tokens: None,
+        preferred_listen_addr: Some("127.0.0.1:0"),
+        gateway_auth_token_hash: None,
+        gateway_admin_tokens: Vec::new(),
+        gateway_sso: RuntimeGatewaySsoConfig::default(),
+        gateway_state_store: RuntimeGatewayStateStore::file(&paths),
+        gateway_virtual_keys: Vec::new(),
+        gateway_route_aliases: Vec::new(),
+        gateway_guardrails: runtime_proxy_crate::RuntimeGatewayGuardrailConfig::default(),
+        gateway_guardrail_webhook: RuntimeGatewayGuardrailWebhookConfig::default(),
+        gateway_call_id_header: Some("x-prodex-call-id".to_string()),
+        gateway_observability: RuntimeGatewayObservabilityConfig::default(),
+    })
+    .expect("profile-auth gateway proxy should start without upstream API keys");
+
+    let client = reqwest::blocking::Client::new();
+    let session_response = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .header("session_id", "session_bound")
+        .json(&serde_json::json!({
+            "model": "gpt-5.4",
+            "input": "continue the session",
+        }))
+        .send()
+        .expect("session continuation should be sent");
+    assert_eq!(session_response.status().as_u16(), 200);
+
+    let previous_response = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .json(&serde_json::json!({
+            "model": "gpt-5.4",
+            "input": "continue the response",
+            "previous_response_id": "resp_bound",
+        }))
+        .send()
+        .expect("previous-response continuation should be sent");
+    assert_eq!(previous_response.status().as_u16(), 200);
+
+    let mut response_forwards = Vec::new();
+    for _ in 0..4 {
+        match upstream.body_rx.recv_timeout(Duration::from_millis(250)) {
+            Ok(request)
+                if request.path.ends_with("/codex/responses") && !request.body.is_empty() =>
+            {
+                response_forwards.push(request);
+            }
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    assert_eq!(
+        response_forwards.len(),
+        2,
+        "expected exactly the two client /responses forwards"
+    );
+    for request in response_forwards {
+        assert_eq!(
+            request.headers.get("authorization").map(String::as_str),
+            Some("Bearer bound-access-token")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("chatgpt-account-id")
+                .map(String::as_str),
+            Some("bound-account")
+        );
+    }
 }
 
 #[test]

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/gateway_usage.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/gateway_usage.rs
@@ -69,7 +69,7 @@ fn gateway_virtual_key_usage_is_persisted_and_visible_to_admin_endpoint() {
         .body_rx
         .recv_timeout(Duration::from_secs(2))
         .expect("upstream should receive gateway request");
-    assert!(String::from_utf8_lossy(&upstream_body).contains("gpt-5.4"));
+    assert!(String::from_utf8_lossy(&upstream_body.body).contains("gpt-5.4"));
 
     let usage = client
         .get(format!(

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/profile_auth.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/profile_auth.rs
@@ -1,0 +1,638 @@
+use super::*;
+use crate::{AppState, ProfileEntry, ProfileProvider};
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tiny_http::{Header as TinyHeader, Response as TinyResponse, Server as TinyServer};
+
+#[test]
+fn profile_auth_gateway_forwards_v1_responses_without_openai_api_key() {
+    let _api_key = crate::TestEnvVarGuard::unset("OPENAI_API_KEY");
+    let _api_keys = crate::TestEnvVarGuard::unset("OPENAI_API_KEYS");
+    let root = temp_root("gateway-profile-auth-no-api-key");
+    let paths = app_paths_for_root(root.clone());
+    let state = profile_auth_state(&root, ["main", "second"], "main");
+    let upstream = ScriptedProfileAuthUpstream::start(vec![scripted_json_response(
+        200,
+        serde_json::json!({"id":"resp_profile_auth","output":[]}),
+    )]);
+    let proxy = start_profile_auth_gateway(&paths, &state, upstream.base_url(), None);
+
+    let response = reqwest::blocking::Client::new()
+        .post(format!("http://{}/v1/responses?trace=1", proxy.listen_addr))
+        .json(&serde_json::json!({"model":"gpt-5.5","input":"hello"}))
+        .send()
+        .expect("profile-auth gateway request should send");
+
+    assert_response_status(response, 200);
+    let requests = upstream.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/backend-api/codex/responses?trace=1");
+    assert_eq!(
+        requests[0].authorization.as_deref(),
+        Some("Bearer main-token")
+    );
+    assert_eq!(requests[0].account.as_deref(), Some("main-account"));
+}
+
+#[test]
+fn profile_auth_gateway_caller_auth_does_not_select_upstream_profile() {
+    let root = temp_root("gateway-profile-auth-caller-decoupled");
+    let paths = app_paths_for_root(root.clone());
+    let state = profile_auth_state(&root, ["main", "second"], "main");
+    let open_upstream = ScriptedProfileAuthUpstream::start(vec![
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_open","output":[]}),
+        ),
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_open_retry","output":[]}),
+        ),
+    ]);
+    let open_proxy = start_profile_auth_gateway(&paths, &state, open_upstream.base_url(), None);
+    let upstream = ScriptedProfileAuthUpstream::start(vec![
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth","output":[]}),
+        ),
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_retry","output":[]}),
+        ),
+    ]);
+    let proxy = start_profile_auth_gateway(
+        &paths,
+        &state,
+        upstream.base_url(),
+        Some("local-client-token"),
+    );
+    let virtual_key_upstream = ScriptedProfileAuthUpstream::start(vec![
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_alpha","output":[]}),
+        ),
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_beta","output":[]}),
+        ),
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_alpha_retry","output":[]}),
+        ),
+        scripted_json_response(
+            200,
+            serde_json::json!({"id":"resp_profile_auth_beta_retry","output":[]}),
+        ),
+    ]);
+    let client = reqwest::blocking::Client::new();
+
+    let open = client
+        .post(format!("http://{}/v1/responses", open_proxy.listen_addr))
+        .json(&serde_json::json!({"model":"gpt-5.5","input":"no caller auth"}))
+        .send()
+        .expect("request without caller auth should send");
+    assert_response_status(open, 200);
+    let open_requests = open_upstream.requests_after(Duration::from_secs(2), 1);
+    assert!(!open_requests.is_empty());
+    assert!(
+        open_requests
+            .iter()
+            .all(|request| request.authorization.as_deref() == Some("Bearer main-token"))
+    );
+
+    let rejected = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .bearer_auth("wrong-local-client-token")
+        .json(&serde_json::json!({"model":"gpt-5.5","input":"reject me"}))
+        .send()
+        .expect("invalid caller request should send");
+    assert_response_status(rejected, 401);
+    assert!(
+        upstream
+            .requests_after(Duration::from_millis(100), 1)
+            .is_empty(),
+        "configured-invalid inbound auth must be rejected before profile selection"
+    );
+
+    let accepted = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .bearer_auth("local-client-token")
+        .json(&serde_json::json!({"model":"gpt-5.5","input":"accept me"}))
+        .send()
+        .expect("valid caller request should send");
+    assert_response_status(accepted, 200);
+
+    let requests = upstream.requests_after(Duration::from_secs(2), 1);
+    assert!(
+        !requests.is_empty(),
+        "the valid caller request reaches upstream"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.authorization.as_deref() == Some("Bearer main-token"))
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.authorization.as_deref() != Some("Bearer local-client-token"))
+    );
+
+    let alpha_token = "alpha-local-client-token";
+    let beta_token = "beta-local-client-token";
+    let virtual_key_proxy = start_profile_auth_gateway_with_virtual_keys(
+        &paths,
+        &state,
+        virtual_key_upstream.base_url(),
+        None,
+        vec![
+            runtime_proxy_crate::RuntimeGatewayVirtualKey {
+                name: "alpha".to_string(),
+                tenant_id: None,
+                team_id: None,
+                project_id: None,
+                user_id: None,
+                budget_id: None,
+                token_hash: runtime_proxy_crate::LocalBridgeBearerTokenHash::from_token(
+                    alpha_token,
+                ),
+                allowed_models: Vec::new(),
+                budget_microusd: None,
+                request_budget: None,
+                rpm_limit: None,
+                tpm_limit: None,
+            },
+            runtime_proxy_crate::RuntimeGatewayVirtualKey {
+                name: "beta".to_string(),
+                tenant_id: None,
+                team_id: None,
+                project_id: None,
+                user_id: None,
+                budget_id: None,
+                token_hash: runtime_proxy_crate::LocalBridgeBearerTokenHash::from_token(beta_token),
+                allowed_models: Vec::new(),
+                budget_microusd: None,
+                request_budget: None,
+                rpm_limit: None,
+                tpm_limit: None,
+            },
+        ],
+    );
+    for (token, input) in [
+        (alpha_token, "alpha virtual key"),
+        (beta_token, "beta virtual key"),
+    ] {
+        let response = client
+            .post(format!(
+                "http://{}/v1/responses",
+                virtual_key_proxy.listen_addr
+            ))
+            .bearer_auth(token)
+            .json(&serde_json::json!({"model":"gpt-5.5","input":input}))
+            .send()
+            .expect("virtual-key caller request should send");
+        assert_response_status(response, 200);
+    }
+    let virtual_key_requests = virtual_key_upstream.requests_after(Duration::from_secs(2), 2);
+    assert!(
+        virtual_key_requests.len() >= 2,
+        "both virtual-key requests should reach upstream"
+    );
+    let first_profile_auth = virtual_key_requests
+        .first()
+        .and_then(|request| request.authorization.as_deref())
+        .expect("virtual-key profile auth should be injected upstream");
+    assert!(
+        virtual_key_requests
+            .iter()
+            .all(|request| request.authorization.as_deref() == Some(first_profile_auth)),
+        "different inbound virtual keys must not change upstream profile choice: {virtual_key_requests:?}"
+    );
+    assert!(
+        virtual_key_requests.iter().all(|request| {
+            !matches!(
+                request.authorization.as_deref(),
+                Some("Bearer alpha-local-client-token") | Some("Bearer beta-local-client-token")
+            )
+        }),
+        "inbound virtual keys must not become upstream profile credentials: {virtual_key_requests:?}"
+    );
+}
+
+#[test]
+fn profile_auth_gateway_uses_fresh_selection_and_continuation_affinity() {
+    let root = temp_root("gateway-profile-auth-affinity");
+    let paths = app_paths_for_root(root.clone());
+    let mut state = profile_auth_state(&root, ["main", "second"], "second");
+    state.response_profile_bindings.insert(
+        "resp-main".to_string(),
+        crate::ResponseProfileBinding {
+            profile_name: "main".to_string(),
+            bound_at: chrono::Local::now().timestamp(),
+        },
+    );
+    let upstream = ScriptedProfileAuthUpstream::start(vec![
+        scripted_json_response(200, serde_json::json!({"id":"resp-second","output":[]})),
+        scripted_json_response(200, serde_json::json!({"id":"resp-main-next","output":[]})),
+    ]);
+    let proxy = start_profile_auth_gateway(&paths, &state, upstream.base_url(), None);
+    let client = reqwest::blocking::Client::new();
+
+    let fresh = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .json(&serde_json::json!({"model":"gpt-5.5","input":"fresh"}))
+        .send()
+        .expect("fresh request should send");
+    assert_response_status(fresh, 200);
+
+    let continuation = client
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .json(&serde_json::json!({
+            "model":"gpt-5.5",
+            "previous_response_id":"resp-main",
+            "input":"continue"
+        }))
+        .send()
+        .expect("continuation request should send");
+    assert_response_status(continuation, 200);
+
+    let requests = upstream.requests_after(Duration::from_secs(2), 2);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.authorization.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("Bearer second-token"), Some("Bearer main-token")]
+    );
+}
+
+#[test]
+fn profile_auth_gateway_rotates_precommit_failures_and_pins_stream_success() {
+    let root = temp_root("gateway-profile-auth-rotation");
+    let paths = app_paths_for_root(root.clone());
+    let state = profile_auth_state(&root, ["main", "second"], "main");
+    let upstream = ScriptedProfileAuthUpstream::start(vec![
+        scripted_json_response(
+            429,
+            serde_json::json!({"error":{"code":"rate_limit_exceeded","message":"rate limited"}}),
+        ),
+        ScriptedResponse {
+            status: 200,
+            content_type: "text/event-stream",
+            body: concat!(
+                "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-stream\"}}\n\n",
+                "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-stream\",\"output\":[]}}\n\n",
+                "data: [DONE]\n\n"
+            )
+            .to_string(),
+        },
+    ]);
+    let proxy = start_profile_auth_gateway(&paths, &state, upstream.base_url(), None);
+
+    let response = reqwest::blocking::Client::new()
+        .post(format!("http://{}/v1/responses", proxy.listen_addr))
+        .json(&serde_json::json!({"model":"gpt-5.5","stream":true,"input":"hello"}))
+        .send()
+        .expect("streaming profile-auth request should send");
+    let status = response.status().as_u16();
+    let body = response.text().unwrap_or_else(|err| err.to_string());
+    let response_requests = upstream.requests_after(Duration::from_secs(2), 2);
+    assert_eq!(
+        status, 200,
+        "response body: {body}; response requests: {response_requests:?}"
+    );
+
+    let requests = upstream.requests_after(Duration::from_secs(2), 2);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.account.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("main-account"), Some("second-account")]
+    );
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.authorization.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("Bearer main-token"), Some("Bearer second-token")]
+    );
+    assert_eq!(
+        requests.len(),
+        2,
+        "stream success remains pinned after commit"
+    );
+}
+
+#[test]
+fn profile_auth_gateway_rejects_out_of_scope_endpoints() {
+    let root = temp_root("gateway-profile-auth-scope");
+    let paths = app_paths_for_root(root.clone());
+    let state = profile_auth_state(&root, ["main"], "main");
+    let upstream = ScriptedProfileAuthUpstream::start(Vec::new());
+    let proxy = start_profile_auth_gateway(&paths, &state, upstream.base_url(), None);
+
+    let response = reqwest::blocking::Client::new()
+        .post(format!("http://{}/v1/chat/completions", proxy.listen_addr))
+        .json(&serde_json::json!({"model":"gpt-5.5","messages":[]}))
+        .send()
+        .expect("out-of-scope request should send");
+    assert_response_status(response, 404);
+    assert!(upstream.requests().is_empty());
+}
+
+fn start_profile_auth_gateway(
+    paths: &crate::AppPaths,
+    state: &AppState,
+    upstream_base_url: String,
+    gateway_token: Option<&str>,
+) -> crate::RuntimeRotationProxy {
+    start_profile_auth_gateway_with_virtual_keys(
+        paths,
+        state,
+        upstream_base_url,
+        gateway_token,
+        Vec::new(),
+    )
+}
+
+fn start_profile_auth_gateway_with_virtual_keys(
+    paths: &crate::AppPaths,
+    state: &AppState,
+    upstream_base_url: String,
+    gateway_token: Option<&str>,
+    gateway_virtual_keys: Vec<runtime_proxy_crate::RuntimeGatewayVirtualKey>,
+) -> crate::RuntimeRotationProxy {
+    seed_profile_auth_usage_snapshots(paths, state);
+    start_runtime_local_rewrite_proxy(RuntimeLocalRewriteProxyStartOptions {
+        paths,
+        state,
+        upstream_base_url,
+        provider: RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses,
+        upstream_no_proxy: false,
+        smart_context_enabled: false,
+        presidio_redaction_enabled: false,
+        model_context_window_tokens: None,
+        preferred_listen_addr: Some("127.0.0.1:0"),
+        gateway_auth_token_hash: gateway_token
+            .map(runtime_proxy_crate::LocalBridgeBearerTokenHash::from_token),
+        gateway_admin_tokens: Vec::new(),
+        gateway_sso: RuntimeGatewaySsoConfig::default(),
+        gateway_state_store: RuntimeGatewayStateStore::file(paths),
+        gateway_virtual_keys,
+        gateway_route_aliases: Vec::new(),
+        gateway_guardrails: runtime_proxy_crate::RuntimeGatewayGuardrailConfig::default(),
+        gateway_guardrail_webhook: RuntimeGatewayGuardrailWebhookConfig::default(),
+        gateway_call_id_header: Some("x-prodex-call-id".to_string()),
+        gateway_observability: RuntimeGatewayObservabilityConfig::default(),
+    })
+    .expect("profile-auth gateway should start")
+}
+
+fn seed_profile_auth_usage_snapshots(paths: &crate::AppPaths, state: &AppState) {
+    let now = chrono::Local::now().timestamp();
+    let snapshots = state
+        .profiles
+        .keys()
+        .map(|name| {
+            (
+                name.clone(),
+                crate::RuntimeProfileUsageSnapshot {
+                    checked_at: now,
+                    five_hour_status: crate::RuntimeQuotaWindowStatus::Ready,
+                    five_hour_remaining_percent: 80,
+                    five_hour_reset_at: now + 18_000,
+                    weekly_status: crate::RuntimeQuotaWindowStatus::Ready,
+                    weekly_remaining_percent: 80,
+                    weekly_reset_at: now + 86_400,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    crate::save_runtime_usage_snapshots_for_profiles(paths, &snapshots, &state.profiles)
+        .expect("profile-auth quota fixture snapshots should save");
+    let saved = crate::load_runtime_usage_snapshots(paths, &state.profiles)
+        .expect("profile-auth quota fixture snapshots should reload");
+    assert_eq!(
+        saved.len(),
+        state.profiles.len(),
+        "profile-auth quota fixture snapshots should be available before gateway startup"
+    );
+}
+
+fn profile_auth_state<const N: usize>(
+    root: &std::path::Path,
+    names: [&str; N],
+    active_profile: &str,
+) -> AppState {
+    let profiles = names
+        .into_iter()
+        .map(|name| {
+            let codex_home = root.join(format!("homes/{name}"));
+            write_profile_auth_json(
+                &codex_home.join("auth.json"),
+                &format!("{name}-token"),
+                &format!("{name}-account"),
+            );
+            (
+                name.to_string(),
+                ProfileEntry {
+                    codex_home,
+                    managed: true,
+                    email: Some(format!("{name}@example.test")),
+                    provider: ProfileProvider::Openai,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    AppState {
+        active_profile: Some(active_profile.to_string()),
+        profiles,
+        last_run_selected_at: BTreeMap::new(),
+        response_profile_bindings: BTreeMap::new(),
+        session_profile_bindings: BTreeMap::new(),
+    }
+}
+
+fn write_profile_auth_json(path: &std::path::Path, access_token: &str, account_id: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("auth parent should be created");
+    }
+    fs::write(
+        path,
+        serde_json::json!({
+            "tokens": {
+                "access_token": access_token,
+                "account_id": account_id,
+            }
+        })
+        .to_string(),
+    )
+    .expect("auth.json should be written");
+}
+
+fn scripted_json_response(status: u16, body: serde_json::Value) -> ScriptedResponse {
+    ScriptedResponse {
+        status,
+        content_type: "application/json",
+        body: body.to_string(),
+    }
+}
+
+fn assert_response_status(response: reqwest::blocking::Response, expected: u16) {
+    let status = response.status().as_u16();
+    let body = response.text().unwrap_or_else(|err| err.to_string());
+    assert_eq!(status, expected, "response body: {body}");
+}
+
+struct ScriptedResponse {
+    status: u16,
+    content_type: &'static str,
+    body: String,
+}
+
+#[derive(Clone, Debug)]
+struct ScriptedRequest {
+    path: String,
+    authorization: Option<String>,
+    account: Option<String>,
+}
+
+struct ScriptedProfileAuthUpstream {
+    addr: SocketAddr,
+    requests: Arc<Mutex<Vec<ScriptedRequest>>>,
+    _thread: thread::JoinHandle<()>,
+}
+
+impl ScriptedProfileAuthUpstream {
+    fn start(responses: Vec<ScriptedResponse>) -> Self {
+        let server = TinyServer::http("127.0.0.1:0").expect("scripted upstream should bind");
+        let addr = server
+            .server_addr()
+            .to_ip()
+            .expect("scripted upstream should expose addr");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let requests_thread = Arc::clone(&requests);
+        let mut responses = VecDeque::from(responses);
+        let thread = thread::spawn(move || {
+            loop {
+                let Ok(mut request) = server.recv() else {
+                    break;
+                };
+                let path = request.url().to_string();
+                let authorization = request
+                    .headers()
+                    .iter()
+                    .find(|header| header.field.equiv("Authorization"))
+                    .map(|header| header.value.as_str().to_string());
+                let account = request
+                    .headers()
+                    .iter()
+                    .find(|header| header.field.equiv("ChatGPT-Account-Id"))
+                    .map(|header| header.value.as_str().to_string());
+                drain_fixed_request_body(&mut request);
+                if !path.contains("/codex/responses") {
+                    let mut response =
+                        TinyResponse::from_string(scripted_usage_response_body(account.as_deref()))
+                            .with_status_code(200);
+                    response.add_header(
+                        TinyHeader::from_bytes("content-type", "application/json").unwrap(),
+                    );
+                    let _ = request.respond(response);
+                    continue;
+                }
+                let Some(scripted) = responses.pop_front() else {
+                    let mut response =
+                        TinyResponse::from_string(r#"{"error":"unexpected_request"}"#)
+                            .with_status_code(500);
+                    response.add_header(
+                        TinyHeader::from_bytes("content-type", "application/json").unwrap(),
+                    );
+                    let _ = request.respond(response);
+                    continue;
+                };
+                requests_thread
+                    .lock()
+                    .expect("requests should lock")
+                    .push(ScriptedRequest {
+                        path,
+                        authorization,
+                        account,
+                    });
+                let mut response =
+                    TinyResponse::from_string(scripted.body).with_status_code(scripted.status);
+                response.add_header(
+                    TinyHeader::from_bytes("content-type", scripted.content_type).unwrap(),
+                );
+                let _ = request.respond(response);
+            }
+        });
+
+        Self {
+            addr,
+            requests,
+            _thread: thread,
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://{}/backend-api", self.addr)
+    }
+
+    fn requests(&self) -> Vec<ScriptedRequest> {
+        self.requests.lock().expect("requests should lock").clone()
+    }
+
+    fn requests_after(&self, timeout: Duration, expected: usize) -> Vec<ScriptedRequest> {
+        let started = std::time::Instant::now();
+        while started.elapsed() < timeout {
+            let requests = self.requests();
+            if requests.len() >= expected {
+                return requests;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        self.requests()
+    }
+}
+
+fn drain_fixed_request_body(request: &mut tiny_http::Request) {
+    if let Some(content_len) = request
+        .headers()
+        .iter()
+        .find(|header| header.field.equiv("Content-Length"))
+        .and_then(|header| header.value.as_str().parse::<usize>().ok())
+    {
+        let mut body = vec![0; content_len];
+        request
+            .as_reader()
+            .read_exact(&mut body)
+            .expect("request body should read fixed content length");
+    }
+}
+
+fn scripted_usage_response_body(account: Option<&str>) -> String {
+    let now = chrono::Local::now().timestamp();
+    serde_json::json!({
+        "email": format!("{}@example.test", account.unwrap_or("profile")),
+        "plan_type": "plus",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 20,
+                "reset_at": now + 18_000,
+                "limit_window_seconds": 18_000
+            },
+            "secondary_window": {
+                "used_percent": 20,
+                "reset_at": now + 604_800,
+                "limit_window_seconds": 604_800
+            }
+        }
+    })
+    .to_string()
+}

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/support.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_tests/support.rs
@@ -1,5 +1,6 @@
 use crate::AppPaths;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use std::collections::BTreeMap;
 use std::fs;
 use std::net::SocketAddr;
 use std::sync::mpsc;
@@ -9,8 +10,21 @@ use tiny_http::{Header as TinyHeader, Response as TinyResponse, Server as TinySe
 
 pub(super) struct TestUpstream {
     pub(super) addr: SocketAddr,
-    pub(super) body_rx: mpsc::Receiver<Vec<u8>>,
+    pub(super) body_rx: mpsc::Receiver<TestUpstreamRequest>,
     _thread: thread::JoinHandle<()>,
+}
+
+pub(super) struct TestUpstreamRequest {
+    #[allow(dead_code)]
+    pub(super) path: String,
+    pub(super) headers: BTreeMap<String, String>,
+    pub(super) body: Vec<u8>,
+}
+
+pub(super) struct TestUpstreamResponse {
+    pub(super) status: u16,
+    pub(super) content_type: &'static str,
+    pub(super) body: String,
 }
 
 impl TestUpstream {
@@ -19,6 +33,19 @@ impl TestUpstream {
     }
 
     pub(super) fn start_n(request_count: usize) -> Self {
+        Self::start_responses(
+            (0..request_count)
+                .map(|_| TestUpstreamResponse {
+                    status: 200,
+                    content_type: "application/json",
+                    body: r#"{"id":"resp_test","usage":{"input_tokens":7,"output_tokens":11,"total_tokens":18}}"#
+                        .to_string(),
+                })
+                .collect(),
+        )
+    }
+
+    pub(super) fn start_responses(responses: Vec<TestUpstreamResponse>) -> Self {
         let server = TinyServer::http("127.0.0.1:0").expect("test upstream should bind");
         let addr = server
             .server_addr()
@@ -26,20 +53,33 @@ impl TestUpstream {
             .expect("test upstream should expose TCP addr");
         let (body_tx, body_rx) = mpsc::channel();
         let thread = thread::spawn(move || {
-            for _ in 0..request_count {
+            for scripted in responses {
                 let mut request = server.recv().expect("test upstream should receive request");
                 let mut body = Vec::new();
                 request
                     .as_reader()
                     .read_to_end(&mut body)
                     .expect("test upstream should read request body");
-                let _ = body_tx.send(body);
-                let mut response = TinyResponse::from_string(
-                    r#"{"id":"resp_test","usage":{"input_tokens":7,"output_tokens":11,"total_tokens":18}}"#,
-                )
-                .with_status_code(200);
+                let path = request.url().to_string();
+                let headers = request
+                    .headers()
+                    .iter()
+                    .map(|header| {
+                        (
+                            header.field.as_str().to_ascii_lowercase().to_string(),
+                            header.value.as_str().to_string(),
+                        )
+                    })
+                    .collect();
+                let _ = body_tx.send(TestUpstreamRequest {
+                    path,
+                    headers,
+                    body,
+                });
+                let mut response =
+                    TinyResponse::from_string(scripted.body).with_status_code(scripted.status);
                 response.add_header(
-                    TinyHeader::from_bytes("content-type", "application/json").unwrap(),
+                    TinyHeader::from_bytes("content-type", scripted.content_type).unwrap(),
                 );
                 let _ = request.respond(response);
             }
@@ -210,6 +250,25 @@ pub(super) fn app_paths_for_root(root: std::path::PathBuf) -> AppPaths {
         legacy_shared_codex_root: root.join("shared"),
         root,
     }
+}
+
+pub(super) fn write_openai_profile_auth_json(
+    codex_home: &std::path::Path,
+    access_token: &str,
+    account_id: &str,
+) {
+    fs::create_dir_all(codex_home).expect("profile auth home should be created");
+    fs::write(
+        codex_home.join("auth.json"),
+        serde_json::json!({
+            "tokens": {
+                "access_token": access_token,
+                "account_id": account_id,
+            }
+        })
+        .to_string(),
+    )
+    .expect("profile auth fixture should be written");
 }
 
 pub(super) fn wait_for_usage_file(path: &std::path::Path) -> serde_json::Value {

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_upstream.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_upstream.rs
@@ -312,6 +312,9 @@ pub(super) fn send_runtime_local_rewrite_upstream_request(
                 copilot_context: None,
             })
         }
+        RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses => {
+            anyhow::bail!("gateway profile-auth dispatch is handled by the runtime responses proxy")
+        }
         RuntimeLocalRewriteProviderOptions::LocalEmbeddingsOnly { embedding_model } => {
             let parts = if path_without_query(&request.path_and_query).ends_with("/embeddings") {
                 runtime_local_embeddings_response_parts(request, embedding_model)

--- a/crates/prodex-app/src/runtime_proxy.rs
+++ b/crates/prodex-app/src/runtime_proxy.rs
@@ -38,6 +38,7 @@ pub(crate) use self::chain_log::*;
 pub(crate) use self::classification::*;
 pub(super) use self::continuation::*;
 pub(crate) use self::cookies::*;
+pub(crate) use self::dispatch::respond_runtime_responses_reply;
 pub(crate) use self::dispatch::*;
 pub(crate) use self::failure_response::*;
 pub(super) use self::health::*;

--- a/crates/prodex-app/tests/src/app_commands/runtime_launch.rs
+++ b/crates/prodex-app/tests/src/app_commands/runtime_launch.rs
@@ -16,6 +16,81 @@ mod run_command_strategy;
 mod super_runtime;
 
 #[test]
+fn gateway_without_profile_auth_uses_openai_api_key_mode() {
+    let root = temp_dir("gateway-default-api-key-mode");
+    let _home = TestEnvVarGuard::set("PRODEX_HOME", root.to_str().unwrap());
+    let _api_key = TestEnvVarGuard::unset("OPENAI_API_KEY");
+    let _api_keys = TestEnvVarGuard::set("OPENAI_API_KEYS", "sk-test-first, sk-test-second");
+    let _base_url = TestEnvVarGuard::unset("OPENAI_BASE_URL");
+    let _gateway_token = TestEnvVarGuard::unset("PRODEX_GATEWAY_TOKEN");
+    let paths = AppPaths::discover().unwrap();
+
+    let config = resolve_gateway_launch_config(
+        &paths,
+        &GatewayArgs {
+            listen: Some("127.0.0.1:4100".to_string()),
+            provider: None,
+            base_url: None,
+            api_key: None,
+            profile_auth: false,
+            auth_token: None,
+            smart_context: false,
+            presidio: false,
+            no_presidio: false,
+        },
+        &prodex_runtime_policy::RuntimePolicyGatewaySettings::default(),
+    )
+    .unwrap();
+
+    assert_eq!(config.provider_name, None);
+    assert_eq!(config.listen_addr, "127.0.0.1:4100");
+    assert_eq!(config.auth_token_hash, None);
+    assert!(!config.auth_required);
+    match config.provider_options {
+        RuntimeLocalRewriteProviderOptions::OpenAiResponses { api_keys } => {
+            assert_eq!(api_keys, ["sk-test-first", "sk-test-second"]);
+        }
+        _ => panic!("expected default gateway API-key mode"),
+    }
+}
+
+#[test]
+fn gateway_profile_auth_allows_startup_without_openai_api_key() {
+    let root = temp_dir("gateway-profile-auth-no-openai-api-key");
+    let _home = TestEnvVarGuard::set("PRODEX_HOME", root.to_str().unwrap());
+    let _api_key = TestEnvVarGuard::unset("OPENAI_API_KEY");
+    let _api_keys = TestEnvVarGuard::unset("OPENAI_API_KEYS");
+    let _base_url = TestEnvVarGuard::unset("OPENAI_BASE_URL");
+    let _gateway_token = TestEnvVarGuard::unset("PRODEX_GATEWAY_TOKEN");
+    let paths = AppPaths::discover().unwrap();
+
+    let config = resolve_gateway_launch_config(
+        &paths,
+        &GatewayArgs {
+            listen: Some("127.0.0.1:4100".to_string()),
+            provider: None,
+            base_url: None,
+            api_key: None,
+            profile_auth: true,
+            auth_token: None,
+            smart_context: false,
+            presidio: false,
+            no_presidio: false,
+        },
+        &prodex_runtime_policy::RuntimePolicyGatewaySettings::default(),
+    )
+    .unwrap();
+
+    assert_eq!(config.provider_name, None);
+    assert_eq!(config.listen_addr, "127.0.0.1:4100");
+    assert!(!config.auth_required);
+    assert!(matches!(
+        config.provider_options,
+        RuntimeLocalRewriteProviderOptions::ProfileAuthOpenAiResponses
+    ));
+}
+
+#[test]
 fn gateway_state_store_config_builds_postgres_backend_from_env() {
     let root = temp_dir("gateway-postgres-state-config");
     let _home = TestEnvVarGuard::set("PRODEX_HOME", root.to_str().unwrap());

--- a/crates/prodex-app/tests/support/main_internal/runtime_proxy_continuations/post_commit.rs
+++ b/crates/prodex-app/tests/support/main_internal/runtime_proxy_continuations/post_commit.rs
@@ -423,6 +423,110 @@ fn runtime_proxy_websocket_previous_response_not_found_after_commit_surfaces_sta
 }
 
 #[test]
+fn runtime_proxy_http_stream_keeps_selected_profile_after_commit_failure() {
+    let _test_guard = crate::acquire_test_runtime_lock();
+    let _stream_idle_timeout_guard = ci_runtime_proxy_timeout_guard(
+        "PRODEX_RUNTIME_PROXY_STREAM_IDLE_TIMEOUT_MS",
+        2_000,
+        5_000,
+    );
+
+    let temp_dir = TestDir::isolated();
+    let backend = RuntimeProxyBackend::start_http_delayed_quota_after_output_item_added();
+    let main_home = temp_dir.path.join("homes/main");
+    let second_home = temp_dir.path.join("homes/second");
+    write_auth_json(&main_home.join("auth.json"), "main-account");
+    write_auth_json(&second_home.join("auth.json"), "second-account");
+
+    let state = AppState {
+        active_profile: Some("main".to_string()),
+        profiles: BTreeMap::from([
+            (
+                "main".to_string(),
+                ProfileEntry {
+                    codex_home: main_home,
+                    managed: true,
+                    email: Some("main@example.com".to_string()),
+                    provider: ProfileProvider::Openai,
+                },
+            ),
+            (
+                "second".to_string(),
+                ProfileEntry {
+                    codex_home: second_home,
+                    managed: true,
+                    email: Some("second@example.com".to_string()),
+                    provider: ProfileProvider::Openai,
+                },
+            ),
+        ]),
+        last_run_selected_at: BTreeMap::new(),
+        response_profile_bindings: BTreeMap::from([(
+            "resp-main".to_string(),
+            ResponseProfileBinding {
+                profile_name: "main".to_string(),
+                bound_at: Local::now().timestamp(),
+            },
+        )]),
+        session_profile_bindings: BTreeMap::new(),
+    };
+    let paths = AppPaths {
+        root: temp_dir.path.join("prodex"),
+        state_file: temp_dir.path.join("prodex/state.json"),
+        managed_profiles_root: temp_dir.path.join("prodex/profiles"),
+        shared_codex_root: temp_dir.path.join("shared"),
+        legacy_shared_codex_root: temp_dir.path.join("prodex/shared"),
+    };
+    state.save(&paths).expect("failed to save initial state");
+
+    let proxy = start_runtime_rotation_proxy(&paths, &state, "main", backend.base_url(), false)
+        .expect("runtime proxy should start");
+    let response = Client::builder()
+        .build()
+        .expect("client")
+        .post(format!(
+            "http://{}/backend-api/codex/responses",
+            proxy.listen_addr
+        ))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(
+            serde_json::json!({
+                "model": "gpt-5-codex",
+                "previous_response_id": "resp-main",
+                "input": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "fresh stream",
+                    }],
+                }],
+            })
+            .to_string(),
+        )
+        .send()
+        .expect("responses request should succeed");
+
+    assert_eq!(response.status().as_u16(), 200);
+    let body = read_runtime_http_stream_until(response, |body| {
+        body.contains("response.output_item.added") && body.contains("response.failed")
+    });
+    assert!(
+        body.contains("\"type\":\"response.output_item.added\""),
+        "stream should commit visible output before the failure: {body}"
+    );
+    assert!(
+        body.contains("You've hit your usage limit"),
+        "post-commit quota-shaped failure should be forwarded from the pinned profile: {body}"
+    );
+    assert_eq!(
+        backend.responses_accounts(),
+        vec!["main-account".to_string()],
+        "selected profile must stay pinned after stream commit; no mid-stream rotation to the eligible second profile"
+    );
+}
+
+#[test]
 fn runtime_proxy_http_quota_does_not_fresh_fallback_tool_output_only_requests() {
     let temp_dir = TestDir::isolated();
     let backend = RuntimeProxyBackend::start_http_quota_then_tool_output_fresh_fallback_error();

--- a/crates/prodex-app/tests/support/main_internal/runtime_proxy_selection_and_pressure/selection/profile_selection/affinity.rs
+++ b/crates/prodex-app/tests/support/main_internal/runtime_proxy_selection_and_pressure/selection/profile_selection/affinity.rs
@@ -1,6 +1,39 @@
 use super::*;
 
 #[test]
+fn fresh_response_selection_uses_current_candidate_path_and_pool_member() {
+    let temp_dir = TestDir::isolated();
+    let shared = runtime_shared_for_affinity_selection(&temp_dir, BTreeMap::new());
+    let profile_pool = {
+        let runtime = shared.runtime.lock().expect("runtime lock should succeed");
+        runtime
+            .state
+            .profiles
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>()
+    };
+
+    let selected = select_runtime_response_candidate_for_route(
+        &shared,
+        RuntimeResponseCandidateSelection::fresh(&BTreeSet::new(), RuntimeRouteKind::Responses),
+    )
+    .expect("fresh selection should succeed")
+    .expect("fresh selection should return a profile");
+
+    assert!(
+        profile_pool.contains(&selected),
+        "fresh selection must return a profile from the configured pool: selected={selected:?} pool={profile_pool:?}"
+    );
+    let log = std::fs::read_to_string(&shared.log_path).expect("runtime log should be readable");
+    assert!(
+        log.contains("selection_plan route=responses")
+            && log.contains(format!("selection_pick route=responses profile={selected}").as_str()),
+        "fresh selection should leave observable evidence that it used the runtime candidate path: {log}"
+    );
+}
+
+#[test]
 fn response_selection_preserves_bound_previous_response_affinity_despite_quota() {
     let temp_dir = TestDir::isolated();
     let shared = runtime_shared_for_affinity_selection(

--- a/crates/prodex-cli/src/runtime_args.rs
+++ b/crates/prodex-cli/src/runtime_args.rs
@@ -256,6 +256,13 @@ pub struct GatewayArgs {
     /// Provider API key. Prefer provider-specific env vars for shells/history.
     #[arg(long = "api-key", value_name = "KEY")]
     pub api_key: Option<String>,
+    /// Use Prodex OpenAI profiles for upstream /v1/responses auth instead of API keys.
+    #[arg(
+        long = "profile-auth",
+        default_value_t = false,
+        conflicts_with_all = ["api_key", "provider"]
+    )]
+    pub profile_auth: bool,
     /// Require this bearer token from gateway clients. Env fallback: PRODEX_GATEWAY_TOKEN.
     #[arg(long = "auth-token", value_name = "TOKEN")]
     pub auth_token: Option<String>,

--- a/crates/prodex-cli/tests/src/external_provider.rs
+++ b/crates/prodex-cli/tests/src/external_provider.rs
@@ -176,9 +176,44 @@ fn gateway_provider_args_parse_as_top_level_command() {
     assert_eq!(args.listen.as_deref(), Some("127.0.0.1:4100"));
     assert_eq!(args.provider, Some(SuperExternalProvider::Gemini));
     assert_eq!(args.api_key.as_deref(), Some("test-key"));
+    assert!(!args.profile_auth);
     assert_eq!(args.auth_token.as_deref(), Some("gateway-token"));
     assert!(args.smart_context);
     assert!(args.presidio);
+}
+
+#[test]
+fn gateway_profile_auth_arg_parses_and_conflicts_with_api_key_modes() {
+    let command = parse_cli_command_from([
+        "prodex",
+        "gateway",
+        "--profile-auth",
+        "--listen",
+        "127.0.0.1:4100",
+    ])
+    .expect("profile-auth gateway command should parse");
+    let Commands::Gateway(args) = command else {
+        panic!("expected gateway command");
+    };
+    assert!(args.profile_auth);
+    assert_eq!(args.listen.as_deref(), Some("127.0.0.1:4100"));
+    assert!(args.api_key.is_none());
+    assert!(args.provider.is_none());
+
+    assert!(
+        parse_cli_command_from(["prodex", "gateway", "--profile-auth", "--api-key", "test"])
+            .is_err()
+    );
+    assert!(
+        parse_cli_command_from([
+            "prodex",
+            "gateway",
+            "--profile-auth",
+            "--provider",
+            "gemini"
+        ])
+        .is_err()
+    );
 }
 
 #[test]

--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -27,6 +27,16 @@ Defaults below are production defaults. Test builds use smaller timeouts and lim
 Native OpenAI-compatible upstreams are passed through for `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/images/*`, `/v1/audio/*`, `/v1/batches`, `/v1/rerank`, `/v1/a2a`, `/v1/messages`, and `/v1/models`.
 Provider bridges translate `/v1/responses` where supported and pass native-compatible side endpoints through to the selected upstream.
 
+Profile-backed gateway auth is an explicit startup mode for generic OpenAI-compatible `/v1/responses` clients:
+
+```bash
+unset OPENAI_API_KEY
+PRODEX_GATEWAY_TOKEN=local-client-token \
+  prodex gateway --profile-auth --listen 127.0.0.1:4100
+```
+
+In this mode, Prodex uses the existing OpenAI/Codex profile pool and runtime proxy selection machinery instead of `OPENAI_API_KEY`. API-key-backed gateway mode remains the default when `--profile-auth` is absent, and the two upstream auth modes are mutually exclusive at startup. Client bearer auth remains optional on loopback and is only inbound caller auth; it does not pick, rank, or rotate upstream profiles. The profile-auth gateway scope is `/v1/responses` only: a profile is selected and pinned before request/stream commit, continuation fields reuse existing Responses/session affinity, pre-commit rotation is limited to eligible auth/quota/rate failures, and there is no mid-stream rotation.
+
 | Policy key | Environment override | Default | Meaning |
 | --- | --- | --- | --- |
 | `gateway.listen_addr` | none | `127.0.0.1:4000` | Gateway bind address. Non-loopback binds require `--auth-token`, `PRODEX_GATEWAY_TOKEN`, or `gateway.virtual_keys`. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,6 +99,17 @@ The default output ranks labels by average runtime and includes suggested intege
 
 Use `npm run test:runtime-smoke` for a small local runtime invariant suite before broad runtime work. It runs curated log JSON/marker, header preservation, selection affinity, stale continuation, websocket local pressure, and tuning snapshot checks from the shared runtime manifest without changing the broad runtime or stress suites.
 
+Profile-backed gateway live smoke is local-only and must stay skipped in CI. CI coverage for `prodex gateway --profile-auth` uses pure mocks/fixtures; do not add real OpenAI/Codex credentials, profile tokens, or captured auth headers to source, fixtures, logs, or workflow configuration. To run a credentialed local smoke on a machine that already has Prodex OpenAI/Codex profiles configured, opt in explicitly and keep `CI` unset:
+
+```bash
+unset CI OPENAI_API_KEY
+PRODEX_PROFILE_AUTH_GATEWAY_SMOKE=1 \
+PRODEX_GATEWAY_TOKEN=local-client-token \
+  prodex gateway --profile-auth --listen 127.0.0.1:4100
+```
+
+Then send one `/v1/responses` request from a generic OpenAI-compatible client using `base_url` / `baseURL` `http://127.0.0.1:4100/v1` and the local gateway token when one is configured. The smoke must not run from CI; public PR verification relies on mock tests plus the repository secret-scan job.
+
 Use `npm run test:gemini-schema` after changing Gemini request, response, SSE, tool-schema, or Gemini Live translation code. It is offline and guards the Codex-to-Gemini schema snippets, response metadata mapping, SSE event surface, and Live event vocabulary.
 
 Use `PRODEX_LIVE_GEMINI=1 npm run test:gemini-live` only on machines with configured Gemini credentials. The default path sends one exact-response smoke request. Add `PRODEX_LIVE_GEMINI_EXTENDED=1` to cover exact shell output, file edits, `apply_patch`, reference-repo clone/inspection, optional-tool update discipline, semantic compact, and explicit `exec resume`; add `PRODEX_LIVE_GEMINI_MCP=1` or `PRODEX_LIVE_GEMINI_MULTIMODAL=1` when that environment should also exercise MCP or image-input paths. The live smoke compares the final Codex agent message exactly, so Gemini narration or bridge leakage fails the gate.


### PR DESCRIPTION
## Summary

Adds an explicit profile-backed gateway mode for generic OpenAI-compatible `/v1/responses` clients:

```bash
prodex gateway --profile-auth --listen 127.0.0.1:4100
```

In this mode Prodex uses managed profile auth/rotation instead of upstream `OPENAI_API_KEY`, while the existing API-key-backed gateway path remains the default when `--profile-auth` is absent.

## Scope

- `/v1/responses` only
- no model routing
- no `prodex-auto` alias
- no Hermes-specific behavior
- inbound gateway auth remains caller auth only and does not select/influence upstream profile choice
- profile selection/auth reuse existing runtime proxy semantics for profile affinity and no mid-stream rotation

## Verification

Local checks run on macOS:

```text
cargo fmt --check
PASS

cargo test -q -p prodex-app profile_auth -- --test-threads=1
PASS: 11 passed

cargo test -q -p prodex-cli external_provider -- --test-threads=1
PASS: 11 passed

cargo test -q -p prodex-app runtime_proxy_http_stream_keeps_selected_profile_after_commit_failure -- --test-threads=1
PASS: 1 passed

gitleaks detect --no-git --redact --source .
PASS: no leaks found
```

Additional supervisor check:

```text
cargo test -q -p prodex-app runtime_proxy_ -- --test-threads=1
```

This broader focused suite still has pre-existing/flaky macOS failures. Baseline `origin/main` on this machine fails with 8 existing failures in this suite, mostly websocket continuation IO/ResetWithoutClosingHandshake and one inflight relief test. The feature branch does not make the profile-auth focused tests fail, but the broad suite remains unsuitable as a green gate on this machine without addressing those baseline failures separately.

## Notes

The new profile-auth tests use pure mocked/fixture auth and upstreams. No real profile tokens or API keys are committed or required for CI-safe verification.
