### PR TITLE
fix: skip Codex managed packages directory when copying CODEX_HOME

### DIFF
--- a/crates/prodex-shared-codex-fs/src/copy.rs
+++ b/crates/prodex-shared-codex-fs/src/copy.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Directory the Codex installer manages under `CODEX_HOME`. It holds release
+/// trees plus a `standalone/current` symlink that points at a directory, so it
+/// is neither profile state nor safely copyable as files.
+const CODEX_MANAGED_PACKAGES_DIR_NAME: &str = "packages";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexManagedPackages {
+    Copy,
+    SkipAtRoot,
+}
+
 pub fn copy_codex_home(source: &Path, destination: &Path) -> Result<()> {
     if !source.is_dir() {
         bail!("copy source {} is not a directory", source.display());
@@ -17,23 +28,34 @@ pub fn copy_codex_home(source: &Path, destination: &Path) -> Result<()> {
     }
 
     create_codex_home_if_missing(destination)?;
-    copy_directory_contents(source, destination)
+    copy_directory_contents_under_root(
+        source,
+        source,
+        destination,
+        CodexManagedPackages::SkipAtRoot,
+    )
 }
 
 pub(super) fn copy_directory_contents(source: &Path, destination: &Path) -> Result<()> {
-    copy_directory_contents_under_root(source, source, destination)
+    copy_directory_contents_under_root(source, source, destination, CodexManagedPackages::Copy)
 }
 
 fn copy_directory_contents_under_root(
     source_root: &Path,
     source: &Path,
     destination: &Path,
+    managed_packages: CodexManagedPackages,
 ) -> Result<()> {
     for entry in fs::read_dir(source)
         .with_context(|| format!("failed to read directory {}", source.display()))?
     {
         let entry =
             entry.with_context(|| format!("failed to read entry in {}", source.display()))?;
+        if managed_packages == CodexManagedPackages::SkipAtRoot
+            && entry.file_name() == CODEX_MANAGED_PACKAGES_DIR_NAME
+        {
+            continue;
+        }
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
         let file_type = entry
@@ -53,7 +75,12 @@ fn copy_directory_entry(
 ) -> Result<()> {
     if file_type.is_dir() {
         create_codex_home_if_missing(destination_path)?;
-        return copy_directory_contents_under_root(source_root, source_path, destination_path);
+        return copy_directory_contents_under_root(
+            source_root,
+            source_path,
+            destination_path,
+            CodexManagedPackages::Copy,
+        );
     }
 
     if file_type.is_file() {

--- a/crates/prodex-shared-codex-fs/tests/src/copy.rs
+++ b/crates/prodex-shared-codex-fs/tests/src/copy.rs
@@ -107,6 +107,58 @@ fn copy_directory_contents_does_not_preserve_symlink_escape() {
 
 #[cfg(unix)]
 #[test]
+fn copy_codex_home_skips_codex_managed_packages_directory() {
+    let temp_dir = CopyTestDir::new("codex-packages");
+    let source = temp_dir.path.join("source");
+    let destination = temp_dir.path.join("destination");
+    let release_dir = source.join("packages/standalone/releases/0.145.0-aarch64-apple-darwin");
+    let current_link = source.join("packages/standalone/current");
+
+    fs::create_dir_all(&release_dir).expect("release dir should be created");
+    fs::write(release_dir.join("codex"), "binary").expect("release binary should write");
+    std::os::unix::fs::symlink(
+        Path::new("releases/0.145.0-aarch64-apple-darwin"),
+        &current_link,
+    )
+    .expect("release symlink should be created");
+    fs::write(source.join("config.toml"), "model = \"gpt-5\"\n").expect("config should write");
+
+    copy_codex_home(&source, &destination)
+        .expect("Codex managed packages directory must not fail the copy");
+
+    assert_eq!(
+        fs::read_to_string(destination.join("config.toml")).expect("config should be readable"),
+        "model = \"gpt-5\"\n"
+    );
+    assert!(
+        fs::symlink_metadata(destination.join("packages")).is_err(),
+        "Codex managed packages directory should not be copied into the profile"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn copy_codex_home_copies_nested_packages_directory() {
+    let temp_dir = CopyTestDir::new("nested-packages");
+    let source = temp_dir.path.join("source");
+    let destination = temp_dir.path.join("destination");
+    let nested_file = source.join("skills/packages/manifest.json");
+
+    fs::create_dir_all(nested_file.parent().expect("nested parent"))
+        .expect("nested parent should be created");
+    fs::write(&nested_file, "{}").expect("nested file should write");
+
+    copy_codex_home(&source, &destination).expect("copy should succeed");
+
+    assert_eq!(
+        fs::read_to_string(destination.join("skills/packages/manifest.json"))
+            .expect("nested file should be readable"),
+        "{}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn copy_directory_contents_localizes_internal_file_symlink() {
     let temp_dir = CopyTestDir::new("internal-file-symlink");
     let source = temp_dir.path.join("source");


### PR DESCRIPTION
## Problem

`prodex profile import-current <name>` fails on a current Codex install:

```
Error: expected /Users/<user>/.codex/packages/standalone/releases/0.145.0-aarch64-apple-darwin to be a file for shared Codex state
```

The Codex installer keeps release trees under `CODEX_HOME/packages` and points `packages/standalone/current` at a release **directory**:

```
~/.codex/packages/standalone/current -> releases/0.145.0-aarch64-apple-darwin
```

`copy_codex_home` walks into that symlink, `copy_symlinked_file_under_root` canonicalizes it to a directory inside the source root, and hands it to `copy_shared_codex_file_replacing_existing`, which bails. The failed run also leaves a partially copied, unregistered profile directory behind (~1.7 GB per attempt, since release binaries were being copied too).

Fixes #40

## Change

Skip only the **root** `packages` entry in `copy_codex_home`. It is Codex installer state, not profile state, so profiles no longer duplicate release binaries either.

Deliberately narrow:

- `copy_directory_contents` (migration / `move_directory`) keeps its current behavior — those callers copy individual shared subtrees, not a whole `CODEX_HOME`.
- Nested directories named `packages` (e.g. `skills/packages/`) are still copied.
- Existing symlink handling (escape rejection, internal file symlink localization) is untouched.

## Tests

Two regression tests in `crates/prodex-shared-codex-fs/tests/src/copy.rs`:

- `copy_codex_home_skips_codex_managed_packages_directory` — reproduces the exact Codex layout; fails on `main` with the error above, passes with the fix, and asserts unrelated root files still copy.
- `copy_codex_home_copies_nested_packages_directory` — guards that the skip is root-only.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked -p prodex-shared-codex-fs --all-targets --all-features -- -D warnings` — clean
- `cargo test --locked -p prodex-shared-codex-fs` — 64 passed
- `cargo test --locked --workspace` — one unrelated pre-existing failure on macOS, `prodex-runtime-gemini-cli-compat::tests::gemini_cli_compat_bridges_settings_mcp_over_extension_mcp_and_hooks`, which fails identically on an unmodified checkout (same crate also trips `clippy::needless_return` at `crates/prodex-runtime-gemini-cli-compat/src/settings.rs:138` in the macOS-only branch). Left alone to keep this PR narrow.