### PR TITLE
fix(ci): refresh RTK release audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ prodex caveman --dry-run
 
 The target directory must not already exist. Prodex validates the commit metadata and complete tree digest before activating Caveman.
 
-RTK (latest stable `0.47.0`, externally managed):
+RTK (latest stable `0.48.0`, externally managed):
 
 ```bash
 brew install rtk

--- a/crates/prodex-optional-tools/src/lib.rs
+++ b/crates/prodex-optional-tools/src/lib.rs
@@ -40,7 +40,7 @@ pub const PONYTAIL_VETTED_COMMIT: &str = "0a4dd63ad4541f4f655c4108a295916f3c1d8f
 pub const PONYTAIL_VETTED_TREE_SHA256: &str =
     "88c6dfa10bc0a63385a8f3f01bc4a3e51963c8fd76a0ebc0426bd889f0705970";
 pub(crate) const PLAYWRIGHT_MCP_PACKAGE: &str = "@playwright/mcp@0.0.80";
-pub(crate) const RTK_RECOMMENDED_VERSION: &str = "0.47.0";
+pub(crate) const RTK_RECOMMENDED_VERSION: &str = "0.48.0";
 pub(crate) const CODEBASE_MEMORY_RECOMMENDED_VERSION: &str = "0.10.8";
 pub(crate) const PRESIDIO_RECOMMENDED_VERSION: &str = "2.2.364";
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -97,7 +97,7 @@ Ponytail uses the same manifest and tree-validation contract at
 - commit: `0a4dd63ad4541f4f655c4108a295916f3c1d8fda`
 - tree SHA-256: `88c6dfa10bc0a63385a8f3f01bc4a3e51963c8fd76a0ebc0426bd889f0705970`
 
-RTK `0.47.0` is the latest stable release validated for this Prodex release; it remains
+RTK `0.48.0` is the latest stable release validated for this Prodex release; it remains
 externally managed and version-compatible rather than latest-only. Codebase Memory MCP
 `0.10.8` is the latest stable release validated for this Prodex release. Both resolve from
 managed roots first and then `PATH`.

--- a/migration/optional-tools-audit.json
+++ b/migration/optional-tools-audit.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "audited_at": "2026-09-04T05:26:30Z",
-  "release": "0.426.0",
+  "audited_at": "2026-09-05T07:58:38Z",
+  "release": "0.426.1",
   "tools": [
     {
       "id": "caveman",
@@ -22,16 +22,16 @@
     {
       "id": "rtk",
       "repository": "https://github.com/rtk-ai/rtk",
-      "latest_stable": "0.47.0",
-      "release": "v0.47.0",
-      "commit": "34fe2553192aef5f6ca19944cb52a272a5294c27",
-      "git_tree": "ac0e604b5f1809ce2b1f717db65c3f620cc28ad2",
-      "checksums_asset": "sha256:ecb918b8ec017d3604981097f1b9a69dd50e8eaa6806580b0b852e24c5961df5",
+      "latest_stable": "0.48.0",
+      "release": "v0.48.0",
+      "commit": "fde0a8f185945556f51718de0f4c430bb62b3df6",
+      "git_tree": "183f99b26ac0b945119f42a589d8e9257fe7eec8",
+      "checksums_asset": "sha256:5dfd96e853c11e8becf0e11be2535676f497a5949266824e331ddafecb406265",
       "license": "Apache-2.0",
       "runtime": "Externally managed executable; recommended, not latest-only",
       "platforms": ["linux", "macos", "windows"],
       "decision": "ADOPT_PACKAGE",
-      "notes": "Latest release audited for find, git, stream decoding, and Windows console behavior."
+      "notes": "v0.48.0 is the latest stable release; the exact release commit, Git tree, and checksum manifest digest are pinned."
     },
     {
       "id": "codebase-memory-mcp",


### PR DESCRIPTION
Refresh the release-time optional-tool audit to the current stable RTK 0.48.0 release.

- pins the official release commit, Git tree, and checksum manifest digest
- aligns the recommended version and user-facing documentation
- fixes standalone release freshness validation

Validation: optional-tools freshness check, 51 optional-tools tests, docs lint, cargo fmt, Mojo production-share checks, and diff checks pass.