### PR TITLE
test(ci): refresh Mojo share fixture after B0-049

### DIFF
--- a/scripts/ci/mojo-production-share.test.mjs
+++ b/scripts/ci/mojo-production-share.test.mjs
@@ -215,8 +215,8 @@ test("canonical report exposes separate statuses and --check enforces only floor
   const report = JSON.parse(runShare("--json"));
   assert.equal(report.current_prodex_version, await readCargoVersion());
   assert.equal(report.final.broad_mojo_production_loc, 26_420);
-  assert.equal(report.final.broad_total_production_loc, 374_798);
-  assert.equal(report.final.broad_mojo_percent, 7.049130464943783);
+  assert.equal(report.final.broad_total_production_loc, 374_895);
+  assert.equal(report.final.broad_mojo_percent, 7.047306579175502);
   assert.equal(report.release_floor_percent, 7);
   assert.equal(report.release_floor_met, true);
   assert.equal(report.release_floor_status, "PASS");


### PR DESCRIPTION
## Recovery split qualification

- Base: `63ac37d64a8494a6667f4a7e34fbd3a4b3be9ef9`
- Head: `ca5d6c9a0ad37b3ea07e8ea6c666174e376441a6`
- Head tree: `b8236547f88be176da0c98a05ff54e465fd5c5ac`
- Dependency: PR78 B0-049 exact repair; PR78 run `34436673613` failed only on stale Mojo fixture `374798 != 374895`.

This split changes only the two authoritative fixture assertions. Local `--check` and 13/13 fixture tests pass. No production code, threshold, waiver, or counting logic changed. This is a draft recovery qualification PR; do not merge protected main.
