### PR TITLE
test(presidio): cover blocking inverted ranges

### DIFF
--- a/crates/prodex-presidio/src/blocking_http.rs
+++ b/crates/prodex-presidio/src/blocking_http.rs
@@ -268,6 +268,37 @@ mod tests {
     }
 
     #[test]
+    fn presidio_analyze_rejects_inverted_finding_range() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            let body = r#"[{"start":3,"end":1,"score":1.0,"entity_type":"PERSON"}]"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let error = presidio_analyze(
+            &presidio_http_client().unwrap(),
+            &format!("http://{address}"),
+            "synthetic-input",
+            "en",
+        )
+        .expect_err("inverted analyzer ranges must be rejected")
+        .to_string();
+
+        assert_eq!(error, "Presidio Analyzer returned an invalid finding range");
+        server.join().unwrap();
+    }
+
+    #[test]
     fn config_aware_blocking_client_enforces_timeout_and_response_limit() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();


### PR DESCRIPTION
## Recovery coverage closure

- Base: `ca5d6c9a0ad37b3ea07e8ea6c666174e376441a6`
- Head: `c076a4636592644f86fd635e31fed9f9d071be22`
- Tree: `1aeaac5a5c97d0226ecdc4be1fd9712448a2a054`
- One test-only path change: `crates/prodex-presidio/src/blocking_http.rs`.
- Adds loopback blocking analyzer response with `start=3,end=1`; asserts fail-closed invalid-range error.
- Exact writer/reviewer reports retained; `prodex-presidio` 11/11 passes.

Draft recovery PR only. Do not merge protected main or release.
