### PR TITLE
feat(expose): add session preempt control plane

### DIFF
--- a/crates/prodex-app/src/expose.rs
+++ b/crates/prodex-app/src/expose.rs
@@ -74,12 +74,6 @@ mod mcp_tests;
 #[path = "expose/run_manager_tests.rs"]
 mod run_manager_tests;
 #[cfg(all(test, unix))]
-#[path = "expose/session_preempt_live_tests.rs"]
-mod session_preempt_live_tests;
-#[cfg(all(test, unix))]
-#[path = "expose/session_preempt_tests.rs"]
-mod session_preempt_tests;
-#[cfg(all(test, unix))]
 #[path = "expose/session_prompt_write_concurrency_tests.rs"]
 mod session_prompt_write_concurrency_tests;
 #[cfg(all(test, unix))]

--- a/crates/prodex-app/src/expose.rs
+++ b/crates/prodex-app/src/expose.rs
@@ -74,6 +74,12 @@ mod mcp_tests;
 #[path = "expose/run_manager_tests.rs"]
 mod run_manager_tests;
 #[cfg(all(test, unix))]
+#[path = "expose/session_preempt_live_tests.rs"]
+mod session_preempt_live_tests;
+#[cfg(all(test, unix))]
+#[path = "expose/session_preempt_tests.rs"]
+mod session_preempt_tests;
+#[cfg(all(test, unix))]
 #[path = "expose/session_prompt_write_concurrency_tests.rs"]
 mod session_prompt_write_concurrency_tests;
 #[cfg(all(test, unix))]

--- a/crates/prodex-app/src/expose/mcp/handler.rs
+++ b/crates/prodex-app/src/expose/mcp/handler.rs
@@ -2,8 +2,8 @@ use super::super::http::ExposeHttpRequest;
 use super::super::run_manager::ExposeRunManager;
 use super::super::session::{expose_digest_eq, expose_token_digest};
 use super::super::session_prompt_write::{
-    PromptOutputReadRequest, SESSION_PROMPT_WRITE_MAX_MESSAGE_BYTES, SessionPromptWriteRequest,
-    SessionPromptWriteService,
+    PromptOutputReadRequest, SESSION_PROMPT_WRITE_MAX_MESSAGE_BYTES, SessionPreemptRequest,
+    SessionPromptWriteRequest, SessionPromptWriteService,
 };
 use super::super::ui::{ExposeHttpResponse, expose_mcp_empty_response, expose_text_response};
 use super::protocol::{
@@ -323,7 +323,7 @@ impl ExposeMcpEndpoint {
 
     fn instructions(&self) -> String {
         format!(
-            "This is a local full-access Prodex Super runtime starting in {:?} (instance {}). The initial directory is context, not a filesystem jail: runs retain normal OS-user filesystem, process, network, Git, and local-tool authority. For development requests, resolve one compatible existing plain prodex s with prodex_session_prompt_write first, then read its exact returned PID, thread_id, and cursor. Start one prodex_super_start fallback only after authoritative no_session; never run both paths in parallel or treat ambiguity, stale identity, addressability, queue, source, or verification errors as no_session. A fresh idle prodex s needs no manual bootstrap prompt. Include consequential external actions in the user's task, and poll an existing run instead of starting duplicates. The expose URL is ephemeral capability authentication; anyone with it can control this instance.",
+            "This is a local full-access Prodex Super runtime starting in {:?} (instance {}). The initial directory is context, not a filesystem jail: runs retain normal OS-user filesystem, process, network, Git, and local-tool authority. For development requests, resolve one compatible existing plain prodex s with prodex_session_prompt_write first, then read its exact returned PID, thread_id, and cursor. Use prodex_session_preempt for one exact session when the current turn and all pending queued prompts must stop; it never kills a process. Start one prodex_super_start fallback only after authoritative no_session; never run both paths in parallel or treat ambiguity, stale identity, addressability, queue, source, or verification errors as no_session. A fresh idle prodex s needs no manual bootstrap prompt. Include consequential external actions in the user's task, and poll an existing run instead of starting duplicates. The expose URL is ephemeral capability authentication; anyone with it can control this instance.",
             self.workspace_name, self.instance_id
         )
     }
@@ -371,6 +371,7 @@ impl ExposeMcpEndpoint {
             "prodex_super_result" => self.result_tool(arguments),
             "prodex_super_cancel" => self.cancel_tool(arguments),
             "prodex_session_prompt_write" => self.session_prompt_write_tool(arguments),
+            "prodex_session_preempt" => self.session_preempt_tool(arguments),
             "prodex_session_output_read" => self.output_read_tool(arguments, shutdown),
             "prodex_super_list" => Ok(json!({
                 "instance_id": self.instance_id,
@@ -426,6 +427,43 @@ impl ExposeMcpEndpoint {
             "recovery_generation": result.recovery_generation,
             "last_prompt_requeued": result.last_prompt_requeued,
             "requeue_reason": result.requeue_reason,
+        }))
+    }
+
+    fn session_preempt_tool(&self, arguments: &Value) -> std::result::Result<Value, String> {
+        let prodex_pid = optional_process_id(arguments)?;
+        let thread_id = normalized_thread_id(arguments)?;
+        let binding_key = self.session_binding_key(prodex_pid, thread_id.as_deref());
+        let result = self
+            .session_prompt_write
+            .preempt(SessionPreemptRequest {
+                workspace_root: self.workspace_root.clone(),
+                cwd: optional_string(arguments, "cwd", 4096)?,
+                prodex_pid,
+                thread_id,
+                binding_key,
+            })
+            .map_err(|error| error.as_str().to_string())?;
+        let current_turn_found = result.current_turn_id.is_some();
+        let cancelled_count = result.cancelled_submission_ids.len();
+        let remaining_count = result.remaining_submission_ids.len();
+        Ok(json!({
+            "status": "preempted",
+            "preempted": true,
+            "prodex_pid": result.prodex_pid,
+            "codex_pid": result.codex_pid,
+            "thread_id": result.thread_id,
+            "current_turn_id": result.current_turn_id,
+            "current_turn_found": current_turn_found,
+            "current_turn_interrupted": result.current_turn_interrupted,
+            "cancelled_submission_ids": result.cancelled_submission_ids,
+            "cancelled_count": cancelled_count,
+            "remaining_submission_ids": result.remaining_submission_ids,
+            "remaining_count": remaining_count,
+            "queue_empty_at_boundary": result.queue_empty_at_boundary,
+            "session_ready": result.session_ready,
+            "generation": result.generation,
+            "generation_boundary": result.generation,
         }))
     }
 

--- a/crates/prodex-app/src/expose/mcp/tools.rs
+++ b/crates/prodex-app/src/expose/mcp/tools.rs
@@ -71,6 +71,7 @@ pub(super) fn validate_tool_arguments(
         "prodex_super_events" => ["run_id", "after_seq", "limit"].as_slice(),
         "prodex_super_list" => [].as_slice(),
         "prodex_session_prompt_write" => ["message", "cwd", "prodex_pid", "thread_id"].as_slice(),
+        "prodex_session_preempt" => ["cwd", "prodex_pid", "thread_id"].as_slice(),
         "prodex_session_output_read" => {
             ["cursor", "limit", "wait_ms", "prodex_pid", "thread_id"].as_slice()
         }
@@ -233,7 +234,7 @@ fn config_assignment_has_key(assignment: &str, key: &str) -> bool {
         .is_some_and(|(name, _)| name.trim() == key)
 }
 
-pub(super) fn mcp_tool_names() -> [&'static str; 8] {
+pub(super) fn mcp_tool_names() -> [&'static str; 9] {
     [
         "prodex_super_start",
         "prodex_super_status",
@@ -242,6 +243,7 @@ pub(super) fn mcp_tool_names() -> [&'static str; 8] {
         "prodex_super_cancel",
         "prodex_super_list",
         "prodex_session_prompt_write",
+        "prodex_session_preempt",
         "prodex_session_output_read",
     ]
 }
@@ -331,6 +333,23 @@ pub(super) fn mcp_tools() -> Vec<Value> {
             json!({"type": "object", "properties": {"status": {"type": "string"}, "prodex_pid": {"type": "integer"}, "codex_pid": {"type": "integer"}, "thread_id": {"type": "string"}, "message_id": {"type": ["string", "null"]}, "submission_id": {"type": ["string", "null"]}, "output_cursor": {"type": ["string", "null"]}, "queue_exit": {"type": "integer"}, "verification": {"type": "string"}, "recovery_generation": {"type": "integer"}, "last_prompt_requeued": {"type": "boolean"}, "requeue_reason": {"type": ["string", "null"]}}, "required": ["status", "prodex_pid", "codex_pid", "thread_id", "message_id", "submission_id", "output_cursor", "queue_exit", "verification", "recovery_generation", "last_prompt_requeued", "requeue_reason"]}),
             false,
             false,
+            false,
+        ),
+        tool_definition(
+            "prodex_session_preempt",
+            "Preempt the current turn for one exact existing plain `prodex s` session, then remove every still-pending queued prompt through Codex. It never kills a process or reports an already-started prompt as cancelled; ambiguous queue or interrupt state fails closed.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "cwd": {"type": ["string", "null"], "maxLength": 4096},
+                    "prodex_pid": {"type": ["integer", "null"], "minimum": 1},
+                    "thread_id": {"type": ["string", "null"], "maxLength": 128}
+                },
+                "additionalProperties": false
+            }),
+            json!({"type": "object", "properties": {"status": {"type": "string"}, "preempted": {"type": "boolean"}, "prodex_pid": {"type": "integer"}, "codex_pid": {"type": "integer"}, "thread_id": {"type": "string"}, "current_turn_id": {"type": ["string", "null"]}, "current_turn_found": {"type": "boolean"}, "current_turn_interrupted": {"type": "boolean"}, "cancelled_submission_ids": {"type": "array", "items": {"type": "string"}}, "cancelled_count": {"type": "integer"}, "remaining_submission_ids": {"type": "array", "items": {"type": "string"}}, "remaining_count": {"type": "integer"}, "queue_empty_at_boundary": {"type": "boolean"}, "session_ready": {"type": "boolean"}, "generation": {"type": "integer"}, "generation_boundary": {"type": "integer"}}, "required": ["status", "preempted", "prodex_pid", "codex_pid", "thread_id", "current_turn_id", "current_turn_found", "current_turn_interrupted", "cancelled_submission_ids", "cancelled_count", "remaining_submission_ids", "remaining_count", "queue_empty_at_boundary", "session_ready", "generation", "generation_boundary"]}),
+            false,
+            true,
             false,
         ),
         tool_definition(

--- a/crates/prodex-app/src/expose/session_prompt_write.rs
+++ b/crates/prodex-app/src/expose/session_prompt_write.rs
@@ -6,12 +6,14 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 #[path = "session_prompt_write/output.rs"]
 mod output;
+#[path = "session_prompt_write/preempt.rs"]
+mod preempt;
 #[path = "session_prompt_write/process.rs"]
 mod process;
 #[path = "session_prompt_write/queue.rs"]
@@ -39,6 +41,8 @@ const OUTPUT_READ_MAX_TEXT_BYTES: usize = 8 * 1024;
 const OUTPUT_READ_MAX_TOTAL_TEXT_BYTES: usize = 256 * 1024;
 const OUTPUT_SOURCE_PROBE_BYTES: usize = 64 * 1024;
 const OUTPUT_SKIP_MAX_BYTES: usize = 4 * 1024 * 1024;
+const PREEMPT_QUEUE_DRAIN_ATTEMPTS: usize = 4;
+const PREEMPT_QUEUE_LIMIT: usize = 100;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum SessionPromptWriteError {
@@ -119,6 +123,29 @@ pub(super) struct SessionPromptWriteSuccess {
 }
 
 #[derive(Clone, Debug)]
+pub(super) struct SessionPreemptRequest {
+    pub(super) workspace_root: PathBuf,
+    pub(super) cwd: Option<String>,
+    pub(super) prodex_pid: Option<u32>,
+    pub(super) thread_id: Option<String>,
+    pub(super) binding_key: String,
+}
+
+#[derive(Debug)]
+pub(super) struct SessionPreemptSuccess {
+    pub(super) prodex_pid: u32,
+    pub(super) codex_pid: u32,
+    pub(super) thread_id: String,
+    pub(super) current_turn_id: Option<String>,
+    pub(super) current_turn_interrupted: bool,
+    pub(super) cancelled_submission_ids: Vec<String>,
+    pub(super) remaining_submission_ids: Vec<String>,
+    pub(super) queue_empty_at_boundary: bool,
+    pub(super) session_ready: bool,
+    pub(super) generation: u64,
+}
+
+#[derive(Clone, Debug)]
 pub(super) struct PromptOutputReadRequest {
     pub(super) workspace_root: PathBuf,
     pub(super) cursor: Option<String>,
@@ -160,12 +187,21 @@ pub(super) trait ExistingSessionPromptWrite: Send + Sync {
         &self,
         request: PromptOutputReadRequest,
     ) -> std::result::Result<PromptOutputReadSuccess, SessionPromptWriteError>;
+    fn preempt(
+        &self,
+        _request: SessionPreemptRequest,
+    ) -> std::result::Result<SessionPreemptSuccess, SessionPromptWriteError> {
+        Err(SessionPromptWriteError::QueueUnsupported)
+    }
 }
 
 pub(super) struct SessionPromptWriteService<P = SystemProcessInspector, Q = SystemQueueControl> {
     process: P,
     queue: Q,
     bindings: Mutex<HashMap<String, SessionBinding>>,
+    // ponytail: one endpoint-wide lock; use per-thread locks only if bridge throughput matters.
+    operation_lock: Mutex<()>,
+    preempt_generation: AtomicU64,
 }
 
 #[derive(Clone, Debug)]
@@ -180,6 +216,8 @@ impl Default for SessionPromptWriteService {
             process: SystemProcessInspector,
             queue: SystemQueueControl,
             bindings: Mutex::new(HashMap::new()),
+            operation_lock: Mutex::new(()),
+            preempt_generation: AtomicU64::new(0),
         }
     }
 }
@@ -191,6 +229,8 @@ impl<P, Q> SessionPromptWriteService<P, Q> {
             process,
             queue,
             bindings: Mutex::new(HashMap::new()),
+            operation_lock: Mutex::new(()),
+            preempt_generation: AtomicU64::new(0),
         }
     }
 }
@@ -204,6 +244,10 @@ where
         &self,
         request: SessionPromptWriteRequest,
     ) -> std::result::Result<SessionPromptWriteSuccess, SessionPromptWriteError> {
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .map_err(|_| SessionPromptWriteError::VerificationInconclusive)?;
         let workspace_root = write::canonical_session_prompt_write_workspace(&request)?;
         let binding = self.binding(&request.binding_key)?;
         let mut target =
@@ -268,6 +312,13 @@ where
         request: PromptOutputReadRequest,
     ) -> std::result::Result<PromptOutputReadSuccess, SessionPromptWriteError> {
         SessionPromptWriteService::read_output(self, request)
+    }
+
+    fn preempt(
+        &self,
+        request: SessionPreemptRequest,
+    ) -> std::result::Result<SessionPreemptSuccess, SessionPromptWriteError> {
+        self.preempt_session(request)
     }
 }
 

--- a/crates/prodex-app/src/expose/session_prompt_write/preempt.rs
+++ b/crates/prodex-app/src/expose/session_prompt_write/preempt.rs
@@ -1,0 +1,229 @@
+#[cfg(unix)]
+use super::queue::{QueuePreemptResult, app_server_socket, app_server_thread_activity};
+use super::write::canonical_session_workspace;
+use super::{
+    QueueControl, SessionPreemptRequest, SessionPreemptSuccess, SessionPromptWriteError,
+    SessionPromptWriteService,
+};
+#[cfg(unix)]
+use crate::app_server_control::{AppServerRequestOutcome, UnixAppServerSocket, request_result};
+#[cfg(unix)]
+use std::collections::BTreeSet;
+use std::sync::atomic::Ordering;
+
+impl<P, Q> SessionPromptWriteService<P, Q>
+where
+    P: super::ProcessInspector,
+    Q: QueueControl,
+{
+    pub(super) fn preempt_session(
+        &self,
+        request: SessionPreemptRequest,
+    ) -> std::result::Result<SessionPreemptSuccess, SessionPromptWriteError> {
+        let _operation_guard = self
+            .operation_lock
+            .lock()
+            .map_err(|_| SessionPromptWriteError::VerificationInconclusive)?;
+        let workspace_root =
+            canonical_session_workspace(&request.workspace_root, request.cwd.as_deref())?;
+        let binding = self.binding(&request.binding_key)?;
+        let target = self.resolve_session_preempt_target(
+            request.prodex_pid,
+            request.thread_id.as_deref(),
+            &workspace_root,
+            binding.as_ref(),
+        )?;
+        let target = self.revalidate(&target, &workspace_root)?;
+        let result = self.queue.preempt(&target)?;
+        let generation = self
+            .preempt_generation
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        self.remember_binding(&request.binding_key, target.clone(), None)?;
+        Ok(SessionPreemptSuccess {
+            prodex_pid: target.prodex.pid,
+            codex_pid: target.writer.pid,
+            thread_id: target.thread_id,
+            current_turn_id: result.current_turn_id,
+            current_turn_interrupted: result.current_turn_interrupted,
+            cancelled_submission_ids: result.cancelled_submission_ids,
+            remaining_submission_ids: result.remaining_submission_ids,
+            queue_empty_at_boundary: result.queue_empty_at_boundary,
+            session_ready: result.session_ready,
+            generation,
+        })
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn app_server_preempt(
+    target: &super::ResolvedTarget,
+) -> std::result::Result<QueuePreemptResult, SessionPromptWriteError> {
+    let Some(mut socket) = app_server_socket(target)? else {
+        return Err(SessionPromptWriteError::QueueUnsupported);
+    };
+    let mut request_id = 1;
+    let activity = app_server_thread_activity(&mut socket, target, true, &mut request_id)?
+        .ok_or(SessionPromptWriteError::SessionNotQueueAddressable)?;
+    if activity.active && activity.active_turn_id.is_none() {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+
+    let mut cancelled_submission_ids = Vec::new();
+    let mut queue_empty_at_boundary = false;
+    for _ in 0..super::PREEMPT_QUEUE_DRAIN_ATTEMPTS {
+        let queued = app_server_queue_list(&mut socket, target, &mut request_id)?;
+        if queued.is_empty() {
+            queue_empty_at_boundary = true;
+            break;
+        }
+        for submission_id in queued {
+            if app_server_queue_delete(&mut socket, target, &mut request_id, &submission_id)? {
+                cancelled_submission_ids.push(submission_id);
+            }
+        }
+    }
+    if !queue_empty_at_boundary {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+
+    let activity_at_boundary =
+        app_server_thread_activity(&mut socket, target, true, &mut request_id)?
+            .ok_or(SessionPromptWriteError::SessionNotQueueAddressable)?;
+    if activity_at_boundary.active && activity_at_boundary.active_turn_id.is_none() {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+
+    let turn_id_to_interrupt = match (
+        activity.active_turn_id.as_deref(),
+        activity_at_boundary.active_turn_id.as_deref(),
+    ) {
+        (Some(initial), Some(current)) if initial == current => Some(current.to_string()),
+        (Some(_), None) | (None, None) => None,
+        (Some(_), Some(_)) | (None, Some(_)) => {
+            return Err(SessionPromptWriteError::VerificationInconclusive);
+        }
+    };
+    let mut current_turn_interrupted = false;
+    if let Some(turn_id) = turn_id_to_interrupt.as_deref() {
+        match request_result(
+            &mut socket,
+            next_request_id(&mut request_id),
+            "turn/interrupt",
+            serde_json::json!({"threadId": target.thread_id, "turnId": turn_id}),
+        ) {
+            AppServerRequestOutcome::Accepted(_) => current_turn_interrupted = true,
+            AppServerRequestOutcome::Rejected => {}
+            AppServerRequestOutcome::Ambiguous => {
+                return Err(SessionPromptWriteError::VerificationInconclusive);
+            }
+        }
+    }
+
+    let final_activity = app_server_thread_activity(&mut socket, target, true, &mut request_id)?
+        .ok_or(SessionPromptWriteError::SessionNotQueueAddressable)?;
+    if final_activity.active && final_activity.active_turn_id.is_none() {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+    if final_activity.active_turn_id.is_some() {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+    let remaining_submission_ids = app_server_queue_list(&mut socket, target, &mut request_id)?;
+    if !remaining_submission_ids.is_empty() {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+    let session_ready = !final_activity.active
+        && final_activity.active_turn_id.is_none()
+        && remaining_submission_ids.is_empty();
+    Ok(QueuePreemptResult {
+        current_turn_id: activity.active_turn_id,
+        current_turn_interrupted,
+        cancelled_submission_ids,
+        remaining_submission_ids,
+        queue_empty_at_boundary,
+        session_ready,
+    })
+}
+
+#[cfg(unix)]
+pub(super) fn next_request_id(request_id: &mut u64) -> u64 {
+    let current = *request_id;
+    *request_id = (*request_id).saturating_add(1);
+    current
+}
+
+#[cfg(unix)]
+fn app_server_queue_list(
+    socket: &mut UnixAppServerSocket,
+    target: &super::ResolvedTarget,
+    request_id: &mut u64,
+) -> std::result::Result<Vec<String>, SessionPromptWriteError> {
+    let result = match request_result(
+        socket,
+        next_request_id(request_id),
+        "thread/queue/list",
+        serde_json::json!({
+            "threadId": target.thread_id,
+            "limit": super::PREEMPT_QUEUE_LIMIT,
+        }),
+    ) {
+        AppServerRequestOutcome::Accepted(result) => result,
+        AppServerRequestOutcome::Rejected => return Err(SessionPromptWriteError::QueueFailed),
+        AppServerRequestOutcome::Ambiguous => {
+            return Err(SessionPromptWriteError::VerificationInconclusive);
+        }
+    };
+    if result
+        .get("nextCursor")
+        .is_some_and(|cursor| !cursor.is_null())
+    {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+    let Some(data) = result.get("data").and_then(serde_json::Value::as_array) else {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    };
+    let mut ids = Vec::with_capacity(data.len());
+    let mut seen = BTreeSet::new();
+    for item in data {
+        let Some(id) = item
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty() && id.len() <= 128 && !id.chars().any(char::is_control))
+        else {
+            return Err(SessionPromptWriteError::VerificationInconclusive);
+        };
+        if !seen.insert(id.to_string()) {
+            return Err(SessionPromptWriteError::VerificationInconclusive);
+        }
+        ids.push(id.to_string());
+    }
+    Ok(ids)
+}
+
+#[cfg(unix)]
+fn app_server_queue_delete(
+    socket: &mut UnixAppServerSocket,
+    target: &super::ResolvedTarget,
+    request_id: &mut u64,
+    submission_id: &str,
+) -> std::result::Result<bool, SessionPromptWriteError> {
+    let result = match request_result(
+        socket,
+        next_request_id(request_id),
+        "thread/queue/delete",
+        serde_json::json!({
+            "threadId": target.thread_id,
+            "queuedSubmissionId": submission_id,
+        }),
+    ) {
+        AppServerRequestOutcome::Accepted(result) => result,
+        AppServerRequestOutcome::Rejected => return Err(SessionPromptWriteError::QueueFailed),
+        AppServerRequestOutcome::Ambiguous => {
+            return Err(SessionPromptWriteError::VerificationInconclusive);
+        }
+    };
+    result
+        .get("deleted")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or(SessionPromptWriteError::VerificationInconclusive)
+}

--- a/crates/prodex-app/src/expose/session_prompt_write/queue.rs
+++ b/crates/prodex-app/src/expose/session_prompt_write/queue.rs
@@ -183,6 +183,16 @@ pub(crate) struct QueueInvocation {
     pub(crate) queued: bool,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct QueuePreemptResult {
+    pub(crate) current_turn_id: Option<String>,
+    pub(crate) current_turn_interrupted: bool,
+    pub(crate) cancelled_submission_ids: Vec<String>,
+    pub(crate) remaining_submission_ids: Vec<String>,
+    pub(crate) queue_empty_at_boundary: bool,
+    pub(crate) session_ready: bool,
+}
+
 impl QueueInvocation {
     pub(crate) fn accepted(
         exit_code: Option<i32>,
@@ -230,6 +240,12 @@ pub(crate) trait QueueControl {
         thread_id: &str,
     ) -> std::result::Result<Option<PathBuf>, SessionPromptWriteError>;
     fn queue_once(&self, target: &ResolvedTarget, message: &str) -> QueueInvocation;
+    fn preempt(
+        &self,
+        _target: &ResolvedTarget,
+    ) -> std::result::Result<QueuePreemptResult, SessionPromptWriteError> {
+        Err(SessionPromptWriteError::QueueUnsupported)
+    }
     fn loaded_thread_addressable(
         &self,
         target: &ResolvedTarget,
@@ -334,6 +350,21 @@ impl QueueControl for SystemQueueControl {
         QueueInvocation::accepted(Some(0), Some(message_id), None, true)
     }
 
+    fn preempt(
+        &self,
+        target: &ResolvedTarget,
+    ) -> std::result::Result<QueuePreemptResult, SessionPromptWriteError> {
+        #[cfg(unix)]
+        if target
+            .remote_endpoint
+            .as_deref()
+            .is_some_and(|endpoint| endpoint.starts_with("unix://"))
+        {
+            return super::preempt::app_server_preempt(target);
+        }
+        Err(SessionPromptWriteError::QueueUnsupported)
+    }
+
     #[cfg(unix)]
     fn loaded_thread_addressable(
         &self,
@@ -342,7 +373,8 @@ impl QueueControl for SystemQueueControl {
         let Some(mut socket) = app_server_socket(target)? else {
             return Ok(false);
         };
-        Ok(app_server_thread_activity(&mut socket, target)?.is_some())
+        let mut request_id = 1;
+        Ok(app_server_thread_activity(&mut socket, target, false, &mut request_id)?.is_some())
     }
 }
 
@@ -351,7 +383,11 @@ fn app_server_queue_add_once(target: &ResolvedTarget, message: &str) -> QueueInv
     let Ok(Some(mut socket)) = app_server_socket(target) else {
         return QueueInvocation::preflight();
     };
-    if !matches!(app_server_thread_activity(&mut socket, target), Ok(Some(_))) {
+    let mut request_id = 1;
+    if !matches!(
+        app_server_thread_activity(&mut socket, target, false, &mut request_id),
+        Ok(Some(_))
+    ) {
         return QueueInvocation::preflight();
     }
     let message_id = Uuid::now_v7().to_string();
@@ -360,7 +396,12 @@ fn app_server_queue_add_once(target: &ResolvedTarget, message: &str) -> QueueInv
         "clientUserMessageId": message_id,
         "input": [{"type": "text", "text": message, "textElements": []}],
     });
-    let result = match request_result(&mut socket, 3, "thread/queue/add", params) {
+    let result = match request_result(
+        &mut socket,
+        super::preempt::next_request_id(&mut request_id),
+        "thread/queue/add",
+        params,
+    ) {
         AppServerRequestOutcome::Accepted(result) => result,
         AppServerRequestOutcome::Rejected => return QueueInvocation::default(),
         AppServerRequestOutcome::Ambiguous => return QueueInvocation::ambiguous(),
@@ -400,7 +441,7 @@ fn app_server_queue_add_once(target: &ResolvedTarget, message: &str) -> QueueInv
 }
 
 #[cfg(unix)]
-fn app_server_socket(
+pub(super) fn app_server_socket(
     target: &ResolvedTarget,
 ) -> std::result::Result<Option<UnixAppServerSocket>, SessionPromptWriteError> {
     let Some(endpoint) = target.remote_endpoint.as_deref() else {
@@ -419,13 +460,22 @@ fn app_server_socket(
 }
 
 #[cfg(unix)]
-fn app_server_thread_activity(
+#[derive(Debug)]
+pub(super) struct AppServerThreadActivity {
+    pub(super) active: bool,
+    pub(super) active_turn_id: Option<String>,
+}
+
+#[cfg(unix)]
+pub(super) fn app_server_thread_activity(
     socket: &mut UnixAppServerSocket,
     target: &ResolvedTarget,
-) -> std::result::Result<Option<bool>, SessionPromptWriteError> {
+    include_turns: bool,
+    request_id: &mut u64,
+) -> std::result::Result<Option<AppServerThreadActivity>, SessionPromptWriteError> {
     let Some(initialize) = app_server_request_result(
         socket,
-        1,
+        super::preempt::next_request_id(request_id),
         "initialize",
         serde_json::json!({
             "clientInfo": {
@@ -456,11 +506,11 @@ fn app_server_thread_activity(
         .map_err(|_| SessionPromptWriteError::SessionNotQueueAddressable)?;
     let Some(result) = app_server_request_result(
         socket,
-        2,
+        super::preempt::next_request_id(request_id),
         "thread/read",
         serde_json::json!({
             "threadId": target.thread_id,
-            "includeTurns": false,
+            "includeTurns": include_turns,
         }),
     )?
     else {
@@ -499,7 +549,44 @@ fn app_server_thread_activity(
         "idle" => false,
         _ => return Ok(None),
     };
-    Ok(Some(active))
+    let active_turn_id = if include_turns {
+        thread_active_turn_id(thread)?
+    } else {
+        None
+    };
+    Ok(Some(AppServerThreadActivity {
+        active,
+        active_turn_id,
+    }))
+}
+
+#[cfg(unix)]
+fn thread_active_turn_id(
+    thread: &serde_json::Value,
+) -> std::result::Result<Option<String>, SessionPromptWriteError> {
+    let Some(turns) = thread.get("turns").and_then(serde_json::Value::as_array) else {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    };
+    let active_turns = turns
+        .iter()
+        .filter(|turn| {
+            turn.get("status")
+                .and_then(|status| status.get("type"))
+                .and_then(serde_json::Value::as_str)
+                == Some("inProgress")
+        })
+        .map(|turn| {
+            turn.get("id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty() && id.len() <= 128 && !id.chars().any(char::is_control))
+                .map(str::to_string)
+                .ok_or(SessionPromptWriteError::VerificationInconclusive)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if active_turns.len() > 1 {
+        return Err(SessionPromptWriteError::VerificationInconclusive);
+    }
+    Ok(active_turns.into_iter().next())
 }
 
 #[cfg(unix)]

--- a/crates/prodex-app/src/expose/session_prompt_write/write.rs
+++ b/crates/prodex-app/src/expose/session_prompt_write/write.rs
@@ -18,23 +18,54 @@ where
         workspace_root: &Path,
         binding: Option<&SessionBinding>,
     ) -> std::result::Result<ResolvedTarget, SessionPromptWriteError> {
-        let requested_pid = request
-            .prodex_pid
-            .or_else(|| binding.map(|binding| binding.target.prodex.pid));
+        self.resolve_session_target(
+            workspace_root,
+            request.prodex_pid,
+            request.thread_id.as_deref(),
+            binding,
+        )
+    }
+
+    pub(super) fn resolve_session_preempt_target(
+        &self,
+        requested_pid: Option<u32>,
+        requested_thread_id: Option<&str>,
+        workspace_root: &Path,
+        binding: Option<&SessionBinding>,
+    ) -> std::result::Result<ResolvedTarget, SessionPromptWriteError> {
+        self.resolve_session_target(workspace_root, requested_pid, requested_thread_id, binding)
+    }
+
+    fn resolve_session_target(
+        &self,
+        workspace_root: &Path,
+        requested_pid: Option<u32>,
+        requested_thread_id: Option<&str>,
+        binding: Option<&SessionBinding>,
+    ) -> std::result::Result<ResolvedTarget, SessionPromptWriteError> {
+        let requested_pid =
+            requested_pid.or_else(|| binding.map(|binding| binding.target.prodex.pid));
         let deadline = Instant::now() + QUEUE_COMMAND_TIMEOUT;
         loop {
             let result = self
                 .resolve_target_for_request(
                     workspace_root,
                     requested_pid,
-                    request.thread_id.as_deref(),
+                    requested_thread_id,
                     binding.is_some(),
                 )
-                .map_err(|error| session_prompt_write_resolution_error(request, binding, error));
+                .map_err(|error| {
+                    session_target_resolution_error(
+                        binding,
+                        requested_pid,
+                        requested_thread_id,
+                        error,
+                    )
+                });
             match result {
                 Ok(target) => {
                     self.verify_binding(binding, &target)?;
-                    self.verify_session_prompt_write_identity(request, binding, &target)?;
+                    self.verify_session_target_identity(requested_thread_id, binding, &target)?;
                     self.queue
                         .check_capability(&target)
                         .map_err(|_| SessionPromptWriteError::QueueUnsupported)?;
@@ -51,9 +82,9 @@ where
         }
     }
 
-    fn verify_session_prompt_write_identity(
+    fn verify_session_target_identity(
         &self,
-        request: &SessionPromptWriteRequest,
+        requested_thread_id: Option<&str>,
         binding: Option<&SessionBinding>,
         target: &ResolvedTarget,
     ) -> std::result::Result<(), SessionPromptWriteError> {
@@ -63,11 +94,7 @@ where
                 return Err(SessionPromptWriteError::StaleTarget);
             }
         }
-        if request
-            .thread_id
-            .as_deref()
-            .is_some_and(|thread_id| thread_id != target.thread_id)
-        {
+        if requested_thread_id.is_some_and(|thread_id| thread_id != target.thread_id) {
             return Err(SessionPromptWriteError::StaleTarget);
         }
         Ok(())
@@ -163,11 +190,17 @@ fn rollout_before_offset(
 pub(super) fn canonical_session_prompt_write_workspace(
     request: &SessionPromptWriteRequest,
 ) -> std::result::Result<PathBuf, SessionPromptWriteError> {
-    let workspace_root = request
-        .workspace_root
+    canonical_session_workspace(&request.workspace_root, request.cwd.as_deref())
+}
+
+pub(super) fn canonical_session_workspace(
+    workspace_root: &Path,
+    cwd: Option<&str>,
+) -> std::result::Result<PathBuf, SessionPromptWriteError> {
+    let workspace_root = workspace_root
         .canonicalize()
         .map_err(|_| SessionPromptWriteError::VerificationInconclusive)?;
-    if let Some(cwd) = request.cwd.as_deref() {
+    if let Some(cwd) = cwd {
         let cwd = Path::new(cwd)
             .canonicalize()
             .map_err(|_| SessionPromptWriteError::StaleTarget)?;
@@ -178,13 +211,14 @@ pub(super) fn canonical_session_prompt_write_workspace(
     Ok(workspace_root)
 }
 
-fn session_prompt_write_resolution_error(
-    request: &SessionPromptWriteRequest,
+fn session_target_resolution_error(
     binding: Option<&SessionBinding>,
+    requested_pid: Option<u32>,
+    requested_thread_id: Option<&str>,
     error: SessionPromptWriteError,
 ) -> SessionPromptWriteError {
     if error == SessionPromptWriteError::NoSession
-        && (binding.is_some() || request.prodex_pid.is_some() || request.thread_id.is_some())
+        && (binding.is_some() || requested_pid.is_some() || requested_thread_id.is_some())
     {
         SessionPromptWriteError::StaleTarget
     } else {

--- a/scripts/ci/mojo-production-share.test.mjs
+++ b/scripts/ci/mojo-production-share.test.mjs
@@ -215,8 +215,8 @@ test("canonical report exposes separate statuses and --check enforces only floor
   const report = JSON.parse(runShare("--json"));
   assert.equal(report.current_prodex_version, await readCargoVersion());
   assert.equal(report.final.broad_mojo_production_loc, 26_420);
-  assert.equal(report.final.broad_total_production_loc, 374_432);
-  assert.equal(report.final.broad_mojo_percent, 7.056020852918554);
+  assert.equal(report.final.broad_total_production_loc, 374_843);
+  assert.equal(report.final.broad_mojo_percent, 7.048284214991343);
   assert.equal(report.release_floor_percent, 7);
   assert.equal(report.release_floor_met, true);
   assert.equal(report.release_floor_status, "PASS");


### PR DESCRIPTION
## Stage A of session preempt

Production/control-plane implementation for `prodex_session_preempt`:
- exact plain `prodex s` target resolution
- supported app-server queue list/delete and exact-turn interruption
- thread/read active-turn verification and fail-closed outcomes
- existing prompt-write service integration

This is the first dependency-ordered split. Stage B adds regression tests, docs, and the canonical Mojo fixture update.

Local evidence: cargo check, focused prompt-write tests, fmt, Clippy, docs, and changed-test guards pass on the source tree.
