### PR TITLE
fix(browser): fence session shadow rollback on main path

### DIFF
--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser.rs
@@ -10,9 +10,10 @@ mod store;
 use self::csrf::{CSRF_COOKIE, browser_session_csrf_valid};
 pub(super) use self::store::RuntimeGatewayBrowserState;
 use self::store::{
-    BROWSER_TRANSACTION_TTL_MS, RuntimeGatewayBrowserSession, RuntimeGatewayBrowserTransaction,
-    browser_protect_id_token, browser_store_transaction, browser_take_transaction,
-    browser_unprotect_id_token,
+    BROWSER_SESSION_TTL_MS, BROWSER_TRANSACTION_TTL_MS, RuntimeGatewayBrowserSession,
+    RuntimeGatewayBrowserTransaction, browser_delete_session, browser_delete_session_record,
+    browser_load_session, browser_protect_id_token, browser_store_session,
+    browser_store_transaction, browser_take_transaction, browser_unprotect_id_token,
 };
 
 use super::local_rewrite::RuntimeLocalRewriteProxyShared;
@@ -32,15 +33,12 @@ use crate::{
 };
 
 const MAX_TOKEN_RESPONSE_BYTES: usize = 64 * 1_024;
-const BROWSER_SESSION_TTL_MS: u64 = 8 * 60 * 60 * 1_000;
-const MAX_BROWSER_SESSIONS: usize = 4_096;
 const MAX_BACKCHANNEL_LOGOUT_BYTES: u64 = 8 * 1_024;
 const BACKCHANNEL_LOGOUT_MAX_AGE_SECONDS: u64 = 5 * 60;
 const BACKCHANNEL_LOGOUT_EVENT: &str = "http://schemas.openid.net/event/backchannel-logout";
 const SESSION_COOKIE: &str = "prodex_gateway_session";
 const STATE_COOKIE: &str = "prodex_gateway_oidc_state";
 const LOGOUT_INDEX_KEY_PREFIX: &str = "prodex:gateway:browser:logout:";
-const SESSION_KEY_PREFIX: &str = "prodex:gateway:browser:session:";
 
 #[derive(Clone, Copy)]
 enum RuntimeGatewayBrowserRoute {
@@ -630,138 +628,6 @@ fn redirect_response(
         headers,
         body: Vec::new().into(),
     })
-}
-
-fn browser_store_session(
-    shared: &RuntimeLocalRewriteProxyShared,
-    session_id: String,
-    session: RuntimeGatewayBrowserSession,
-) -> BrowserResult<()> {
-    let now = runtime_gateway_unix_epoch_millis();
-    let mut sessions = shared
-        .gateway_browser
-        .sessions
-        .lock()
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    sessions.retain(|_, session| session.expires_at_unix_ms > now);
-    if sessions.len() >= MAX_BROWSER_SESSIONS
-        && let Some(oldest) = sessions
-            .iter()
-            .min_by_key(|(_, session)| session.expires_at_unix_ms)
-            .map(|(id, _)| id.clone())
-    {
-        sessions.remove(&oldest);
-    }
-    sessions.insert(session_id.clone(), session.clone());
-    drop(sessions);
-    let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() else {
-        return Ok(());
-    };
-    let value =
-        serde_json::to_string(&session).map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    let stored = shared
-        .runtime_shared
-        .async_runtime
-        .handle()
-        .block_on(executor.put_ephemeral(
-            &format!("{SESSION_KEY_PREFIX}{session_id}"),
-            &value,
-            std::time::Duration::from_millis(BROWSER_SESSION_TTL_MS),
-        ))
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    if !stored {
-        shared
-            .gateway_browser
-            .sessions
-            .lock()
-            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?
-            .remove(&session_id);
-        return Err(RuntimeGatewayBrowserFailure::Unavailable);
-    }
-    for logout_key in &session.logout_keys {
-        if shared
-            .runtime_shared
-            .async_runtime
-            .handle()
-            .block_on(executor.add_ephemeral_member(
-                logout_key,
-                &session_id,
-                std::time::Duration::from_millis(BROWSER_SESSION_TTL_MS),
-            ))
-            .is_err()
-        {
-            let _ = browser_delete_session_record(shared, &session_id, Some(&session));
-            return Err(RuntimeGatewayBrowserFailure::Unavailable);
-        }
-    }
-    Ok(())
-}
-
-fn browser_load_session(
-    shared: &RuntimeLocalRewriteProxyShared,
-    session_id: &str,
-) -> BrowserResult<Option<RuntimeGatewayBrowserSession>> {
-    if let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() {
-        let value = shared
-            .runtime_shared
-            .async_runtime
-            .handle()
-            .block_on(executor.get_ephemeral(&format!("{SESSION_KEY_PREFIX}{session_id}")))
-            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-        return value
-            .map(|value| {
-                serde_json::from_str(&value).map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)
-            })
-            .transpose();
-    }
-    let now = runtime_gateway_unix_epoch_millis();
-    let mut sessions = shared
-        .gateway_browser
-        .sessions
-        .lock()
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    sessions.retain(|_, session| session.expires_at_unix_ms > now);
-    Ok(sessions.get(session_id).cloned())
-}
-
-fn browser_delete_session(
-    shared: &RuntimeLocalRewriteProxyShared,
-    session_id: &str,
-) -> BrowserResult<()> {
-    let session = browser_load_session(shared, session_id)?;
-    browser_delete_session_record(shared, session_id, session.as_ref())
-}
-
-fn browser_delete_session_record(
-    shared: &RuntimeLocalRewriteProxyShared,
-    session_id: &str,
-    session: Option<&RuntimeGatewayBrowserSession>,
-) -> BrowserResult<()> {
-    if let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() {
-        shared
-            .runtime_shared
-            .async_runtime
-            .handle()
-            .block_on(executor.delete_ephemeral(&format!("{SESSION_KEY_PREFIX}{session_id}")))
-            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-        if let Some(session) = session {
-            for logout_key in &session.logout_keys {
-                shared
-                    .runtime_shared
-                    .async_runtime
-                    .handle()
-                    .block_on(executor.remove_ephemeral_member(logout_key, session_id))
-                    .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-            }
-        }
-    }
-    shared
-        .gateway_browser
-        .sessions
-        .lock()
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?
-        .remove(session_id);
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser/store.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser/store.rs
@@ -8,15 +8,19 @@ use crate::runtime_launch::proxy_startup::local_rewrite::RuntimeLocalRewriteProx
 use crate::runtime_launch::proxy_startup::local_rewrite_gateway_util::runtime_gateway_unix_epoch_millis;
 
 pub(super) const BROWSER_TRANSACTION_TTL_MS: u64 = 5 * 60 * 1_000;
-const MAX_BROWSER_TRANSACTIONS: usize = 1_024;
+pub(super) const BROWSER_SESSION_TTL_MS: u64 = 8 * 60 * 60 * 1_000;
+pub(super) const MAX_BROWSER_TRANSACTIONS: usize = 1_024;
+pub(super) const MAX_BROWSER_SESSIONS: usize = 4_096;
 const TRANSACTION_KEY_PREFIX: &str = "prodex:gateway:browser:transaction:";
+pub(super) const SESSION_KEY_PREFIX: &str = "prodex:gateway:browser:session:";
 const MAX_PROTECTED_ID_TOKEN_BYTES: usize = 128 * 1_024;
 const ID_TOKEN_ASSOCIATED_DATA_PREFIX: &str = "prodex:gateway:browser:id-token:v1:";
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct RuntimeGatewayBrowserState {
-    pub(super) transactions: Arc<Mutex<BTreeMap<String, RuntimeGatewayBrowserTransaction>>>,
-    pub(super) sessions: Arc<Mutex<BTreeMap<String, RuntimeGatewayBrowserSession>>>,
+    pub(super) transactions: Arc<Mutex<BTreeMap<String, Arc<RuntimeGatewayBrowserTransaction>>>>,
+    pub(super) sessions: Arc<Mutex<BTreeMap<String, Arc<RuntimeGatewayBrowserSession>>>>,
+    pub(super) session_generations: Arc<Mutex<BTreeMap<String, u64>>>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -34,6 +38,45 @@ pub(super) struct RuntimeGatewayBrowserSession {
     #[serde(default)]
     pub(super) logout_keys: Vec<String>,
     pub(super) expires_at_unix_ms: u64,
+}
+
+/// Browser shadow persistence boundary; production maps Redis errors to failure and tests stay offline.
+pub(super) trait BrowserEphemeralPersistence {
+    fn put_ephemeral(&mut self, key: &str, value: &str, ttl: Duration) -> Result<bool, ()>;
+    fn add_ephemeral_member(&mut self, key: &str, member: &str, ttl: Duration) -> Result<(), ()>;
+    fn delete_ephemeral(&mut self, key: &str) -> Result<(), ()>;
+    fn remove_ephemeral_member(&mut self, key: &str, member: &str) -> Result<(), ()>;
+}
+
+struct RedisBrowserEphemeralPersistence<'a> {
+    handle: &'a tokio::runtime::Handle,
+    executor: &'a prodex_storage_redis_runtime::RedisRateLimitExecutor,
+}
+
+impl BrowserEphemeralPersistence for RedisBrowserEphemeralPersistence<'_> {
+    fn put_ephemeral(&mut self, key: &str, value: &str, ttl: Duration) -> Result<bool, ()> {
+        self.handle
+            .block_on(self.executor.put_ephemeral(key, value, ttl))
+            .map_err(|_| ())
+    }
+
+    fn add_ephemeral_member(&mut self, key: &str, member: &str, ttl: Duration) -> Result<(), ()> {
+        self.handle
+            .block_on(self.executor.add_ephemeral_member(key, member, ttl))
+            .map_err(|_| ())
+    }
+
+    fn delete_ephemeral(&mut self, key: &str) -> Result<(), ()> {
+        self.handle
+            .block_on(self.executor.delete_ephemeral(key))
+            .map_err(|_| ())
+    }
+
+    fn remove_ephemeral_member(&mut self, key: &str, member: &str) -> Result<(), ()> {
+        self.handle
+            .block_on(self.executor.remove_ephemeral_member(key, member))
+            .map_err(|_| ())
+    }
 }
 
 pub(super) fn browser_protect_id_token(
@@ -81,8 +124,39 @@ pub(super) fn browser_store_transaction(
     transaction: RuntimeGatewayBrowserTransaction,
 ) -> BrowserResult<()> {
     let now = runtime_gateway_unix_epoch_millis();
-    let mut transactions = shared
-        .gateway_browser
+    let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() else {
+        return browser_store_transaction_with_persistence(
+            &shared.gateway_browser,
+            state,
+            transaction,
+            now,
+            None,
+        );
+    };
+    let mut persistence = RedisBrowserEphemeralPersistence {
+        handle: shared.runtime_shared.async_runtime.handle(),
+        executor,
+    };
+    browser_store_transaction_with_persistence(
+        &shared.gateway_browser,
+        state,
+        transaction,
+        now,
+        Some(&mut persistence),
+    )
+}
+
+pub(super) fn browser_store_transaction_with_persistence(
+    state_store: &RuntimeGatewayBrowserState,
+    state: String,
+    transaction: RuntimeGatewayBrowserTransaction,
+    now: u64,
+    persistence: Option<&mut dyn BrowserEphemeralPersistence>,
+) -> BrowserResult<()> {
+    let value = serde_json::to_string(&transaction)
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let transaction = Arc::new(transaction);
+    let mut transactions = state_store
         .transactions
         .lock()
         .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
@@ -90,33 +164,26 @@ pub(super) fn browser_store_transaction(
     if transactions.len() >= MAX_BROWSER_TRANSACTIONS {
         return Err(RuntimeGatewayBrowserFailure::Unavailable);
     }
-    transactions.insert(state.clone(), transaction.clone());
+    let previous = transactions.insert(state.clone(), Arc::clone(&transaction));
     drop(transactions);
-    let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() else {
+    let Some(persistence) = persistence else {
         return Ok(());
     };
-    let value = serde_json::to_string(&transaction)
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    let stored = shared
-        .runtime_shared
-        .async_runtime
-        .handle()
-        .block_on(executor.put_ephemeral(
-            &format!("{TRANSACTION_KEY_PREFIX}{state}"),
-            &value,
-            Duration::from_millis(BROWSER_TRANSACTION_TTL_MS),
-        ))
-        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-    if !stored {
-        shared
-            .gateway_browser
-            .transactions
-            .lock()
-            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?
-            .remove(&state);
-        return Err(RuntimeGatewayBrowserFailure::Unavailable);
+    match persistence.put_ephemeral(
+        &format!("{TRANSACTION_KEY_PREFIX}{state}"),
+        &value,
+        Duration::from_millis(BROWSER_TRANSACTION_TTL_MS),
+    ) {
+        Ok(true) => Ok(()),
+        Ok(false) | Err(_) => {
+            let mut transactions = state_store
+                .transactions
+                .lock()
+                .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+            restore_owned_entry(&mut transactions, &state, &transaction, previous, None);
+            Err(RuntimeGatewayBrowserFailure::Unavailable)
+        }
     }
-    Ok(())
 }
 
 pub(super) fn browser_take_transaction(
@@ -124,18 +191,27 @@ pub(super) fn browser_take_transaction(
     state: &str,
 ) -> BrowserResult<Option<RuntimeGatewayBrowserTransaction>> {
     if let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() {
+        let local_owner = shared
+            .gateway_browser
+            .transactions
+            .lock()
+            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?
+            .get(state)
+            .cloned();
         let value = shared
             .runtime_shared
             .async_runtime
             .handle()
             .block_on(executor.take_ephemeral(&format!("{TRANSACTION_KEY_PREFIX}{state}")))
             .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
-        shared
-            .gateway_browser
-            .transactions
-            .lock()
-            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?
-            .remove(state);
+        if let Some(local_owner) = local_owner {
+            let mut transactions = shared
+                .gateway_browser
+                .transactions
+                .lock()
+                .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+            restore_owned_entry(&mut transactions, state, &local_owner, None, None);
+        }
         return value
             .map(|value| {
                 serde_json::from_str(&value).map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)
@@ -149,5 +225,316 @@ pub(super) fn browser_take_transaction(
         .lock()
         .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
     transactions.retain(|_, transaction| transaction.expires_at_unix_ms > now);
-    Ok(transactions.remove(state))
+    Ok(transactions
+        .remove(state)
+        .map(|transaction| transaction.as_ref().clone()))
+}
+
+pub(super) fn browser_store_session(
+    shared: &RuntimeLocalRewriteProxyShared,
+    session_id: String,
+    session: RuntimeGatewayBrowserSession,
+) -> BrowserResult<()> {
+    let now = runtime_gateway_unix_epoch_millis();
+    let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() else {
+        return browser_store_session_with_persistence(
+            &shared.gateway_browser,
+            session_id,
+            session,
+            now,
+            None,
+        );
+    };
+    let mut persistence = RedisBrowserEphemeralPersistence {
+        handle: shared.runtime_shared.async_runtime.handle(),
+        executor,
+    };
+    browser_store_session_with_persistence(
+        &shared.gateway_browser,
+        session_id,
+        session,
+        now,
+        Some(&mut persistence),
+    )
+}
+
+pub(super) fn browser_store_session_with_persistence(
+    state_store: &RuntimeGatewayBrowserState,
+    session_id: String,
+    session: RuntimeGatewayBrowserSession,
+    now: u64,
+    persistence: Option<&mut dyn BrowserEphemeralPersistence>,
+) -> BrowserResult<()> {
+    let value =
+        serde_json::to_string(&session).map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let session = Arc::new(session);
+    let mut sessions = state_store
+        .sessions
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let mut session_generations = state_store
+        .session_generations
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    sessions.retain(|_, session| session.expires_at_unix_ms > now);
+    let evicted = if sessions.len() >= MAX_BROWSER_SESSIONS {
+        sessions
+            .iter()
+            .min_by_key(|(_, session)| session.expires_at_unix_ms)
+            .map(|(id, session)| (id.clone(), Arc::clone(session)))
+    } else {
+        None
+    };
+    let evicted = evicted.map(|(oldest, session)| {
+        sessions.remove(&oldest);
+        let generation = advance_session_generation(&mut session_generations, &oldest);
+        (oldest, session, generation)
+    });
+    let previous = sessions.insert(session_id.clone(), Arc::clone(&session));
+    let provisional_generation = advance_session_generation(&mut session_generations, &session_id);
+    prune_session_generations(&sessions, &mut session_generations);
+    drop(session_generations);
+    drop(sessions);
+    let Some(persistence) = persistence else {
+        return Ok(());
+    };
+    if !matches!(
+        persistence.put_ephemeral(
+            &format!("{SESSION_KEY_PREFIX}{session_id}"),
+            &value,
+            Duration::from_millis(BROWSER_SESSION_TTL_MS),
+        ),
+        Ok(true)
+    ) {
+        browser_restore_session_shadow(
+            state_store,
+            &session_id,
+            &session,
+            previous,
+            evicted,
+            provisional_generation,
+        )?;
+        return Err(RuntimeGatewayBrowserFailure::Unavailable);
+    }
+    for logout_key in &session.logout_keys {
+        if persistence
+            .add_ephemeral_member(
+                logout_key,
+                &session_id,
+                Duration::from_millis(BROWSER_SESSION_TTL_MS),
+            )
+            .is_err()
+        {
+            // Redis executor has no compare-delete primitive; retain existing cleanup semantics.
+            let _ = persistence.delete_ephemeral(&format!("{SESSION_KEY_PREFIX}{session_id}"));
+            for logout_key in &session.logout_keys {
+                let _ = persistence.remove_ephemeral_member(logout_key, &session_id);
+            }
+            browser_restore_session_shadow(
+                state_store,
+                &session_id,
+                &session,
+                previous,
+                evicted,
+                provisional_generation,
+            )?;
+            return Err(RuntimeGatewayBrowserFailure::Unavailable);
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn browser_load_session(
+    shared: &RuntimeLocalRewriteProxyShared,
+    session_id: &str,
+) -> BrowserResult<Option<RuntimeGatewayBrowserSession>> {
+    if let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() {
+        let value = shared
+            .runtime_shared
+            .async_runtime
+            .handle()
+            .block_on(executor.get_ephemeral(&format!("{SESSION_KEY_PREFIX}{session_id}")))
+            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+        return value
+            .map(|value| {
+                serde_json::from_str(&value).map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)
+            })
+            .transpose();
+    }
+    let now = runtime_gateway_unix_epoch_millis();
+    let mut sessions = shared
+        .gateway_browser
+        .sessions
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    sessions.retain(|_, session| session.expires_at_unix_ms > now);
+    Ok(sessions
+        .get(session_id)
+        .map(|session| session.as_ref().clone()))
+}
+
+pub(super) fn browser_delete_session(
+    shared: &RuntimeLocalRewriteProxyShared,
+    session_id: &str,
+) -> BrowserResult<()> {
+    let session = browser_load_session(shared, session_id)?;
+    browser_delete_session_record(shared, session_id, session.as_ref())
+}
+
+pub(super) fn browser_delete_session_record(
+    shared: &RuntimeLocalRewriteProxyShared,
+    session_id: &str,
+    session: Option<&RuntimeGatewayBrowserSession>,
+) -> BrowserResult<()> {
+    let local_owner = mark_session_mutation(&shared.gateway_browser, session_id)?;
+    if let Some(executor) = shared.gateway_redis_rate_limit_executor.as_ref() {
+        // Redis executor has no compare-delete primitive; retain existing cleanup semantics.
+        shared
+            .runtime_shared
+            .async_runtime
+            .handle()
+            .block_on(executor.delete_ephemeral(&format!("{SESSION_KEY_PREFIX}{session_id}")))
+            .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+        if let Some(session) = session {
+            for logout_key in &session.logout_keys {
+                shared
+                    .runtime_shared
+                    .async_runtime
+                    .handle()
+                    .block_on(executor.remove_ephemeral_member(logout_key, session_id))
+                    .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+            }
+        }
+    }
+    if let Some(local_owner) = local_owner {
+        remove_owned_session_shadow(&shared.gateway_browser, session_id, &local_owner)?;
+    }
+    Ok(())
+}
+
+fn browser_restore_session_shadow(
+    state_store: &RuntimeGatewayBrowserState,
+    session_id: &str,
+    owner: &Arc<RuntimeGatewayBrowserSession>,
+    previous: Option<Arc<RuntimeGatewayBrowserSession>>,
+    evicted: Option<(String, Arc<RuntimeGatewayBrowserSession>, u64)>,
+    provisional_generation: u64,
+) -> BrowserResult<()> {
+    let mut sessions = state_store
+        .sessions
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let mut session_generations = state_store
+        .session_generations
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let owns_provisional = sessions
+        .get(session_id)
+        .is_some_and(|current| Arc::ptr_eq(current, owner))
+        && session_generation(&session_generations, session_id) == provisional_generation;
+    if owns_provisional {
+        if let Some(previous) = previous {
+            sessions.insert(session_id.to_string(), previous);
+        } else {
+            sessions.remove(session_id);
+        }
+        advance_session_generation(&mut session_generations, session_id);
+        if let Some((evicted_key, evicted, evicted_generation)) = evicted {
+            let expected_generation = if evicted_key == session_id {
+                provisional_generation
+            } else {
+                evicted_generation
+            };
+            if session_generation(&session_generations, &evicted_key) == expected_generation {
+                sessions.entry(evicted_key.clone()).or_insert(evicted);
+                advance_session_generation(&mut session_generations, &evicted_key);
+            }
+        }
+        prune_session_generations(&sessions, &mut session_generations);
+    }
+    Ok(())
+}
+
+pub(super) fn mark_session_mutation(
+    state_store: &RuntimeGatewayBrowserState,
+    session_id: &str,
+) -> BrowserResult<Option<Arc<RuntimeGatewayBrowserSession>>> {
+    let sessions = state_store
+        .sessions
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    let owner = sessions.get(session_id).cloned();
+    let mut session_generations = state_store
+        .session_generations
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    advance_session_generation(&mut session_generations, session_id);
+    prune_session_generations(&sessions, &mut session_generations);
+    Ok(owner)
+}
+
+fn remove_owned_session_shadow(
+    state_store: &RuntimeGatewayBrowserState,
+    session_id: &str,
+    owner: &Arc<RuntimeGatewayBrowserSession>,
+) -> BrowserResult<()> {
+    let mut sessions = state_store
+        .sessions
+        .lock()
+        .map_err(|_| RuntimeGatewayBrowserFailure::Unavailable)?;
+    if sessions
+        .get(session_id)
+        .is_some_and(|current| Arc::ptr_eq(current, owner))
+    {
+        sessions.remove(session_id);
+    }
+    Ok(())
+}
+
+fn session_generation(generations: &BTreeMap<String, u64>, session_id: &str) -> u64 {
+    generations.get(session_id).copied().unwrap_or_default()
+}
+
+fn advance_session_generation(generations: &mut BTreeMap<String, u64>, session_id: &str) -> u64 {
+    let generation = generations.entry(session_id.to_string()).or_default();
+    *generation = generation.saturating_add(1);
+    *generation
+}
+
+fn prune_session_generations(
+    sessions: &BTreeMap<String, Arc<RuntimeGatewayBrowserSession>>,
+    generations: &mut BTreeMap<String, u64>,
+) {
+    while generations.len() > MAX_BROWSER_SESSIONS * 2 {
+        let Some(key) = generations
+            .keys()
+            .find(|key| !sessions.contains_key(*key))
+            .cloned()
+        else {
+            break;
+        };
+        generations.remove(&key);
+    }
+}
+
+fn restore_owned_entry<T>(
+    entries: &mut BTreeMap<String, Arc<T>>,
+    key: &str,
+    owner: &Arc<T>,
+    previous: Option<Arc<T>>,
+    evicted: Option<(String, Arc<T>)>,
+) {
+    if entries
+        .get(key)
+        .is_some_and(|current| Arc::ptr_eq(current, owner))
+    {
+        if let Some(previous) = previous {
+            entries.insert(key.to_string(), previous);
+        } else {
+            entries.remove(key);
+        }
+        if let Some((evicted_key, evicted)) = evicted {
+            let _ = entries.entry(evicted_key).or_insert(evicted);
+        }
+    }
 }

--- a/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser/tests.rs
+++ b/crates/prodex-app/src/runtime_launch/proxy_startup/local_rewrite_gateway_browser/tests.rs
@@ -1,5 +1,13 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
 
+use super::store::{
+    BROWSER_SESSION_TTL_MS, BROWSER_TRANSACTION_TTL_MS, BrowserEphemeralPersistence,
+    MAX_BROWSER_SESSIONS, MAX_BROWSER_TRANSACTIONS, RuntimeGatewayBrowserState, SESSION_KEY_PREFIX,
+    browser_store_session_with_persistence, browser_store_transaction_with_persistence,
+    mark_session_mutation,
+};
 use super::{
     BACKCHANNEL_LOGOUT_EVENT, LOGOUT_INDEX_KEY_PREFIX, RuntimeGatewayBrowserRoute,
     RuntimeGatewayBrowserSession, RuntimeGatewayBrowserTransaction, SESSION_COOKIE,
@@ -119,4 +127,445 @@ fn backchannel_logout_claims_are_recent_event_bound_and_hashed() {
         )
         .is_err()
     );
+}
+
+#[derive(Clone, Copy)]
+enum PutOutcome {
+    Stored,
+    NotStored,
+    Error,
+}
+
+#[derive(Clone, Copy)]
+enum AddOutcome {
+    Stored,
+    Error,
+}
+
+struct FakePersistence {
+    put_outcome: PutOutcome,
+    add_outcome: AddOutcome,
+    put_keys: Vec<String>,
+    put_ttls: Vec<Duration>,
+    add_keys: Vec<String>,
+    add_ttls: Vec<Duration>,
+    deleted_keys: Vec<String>,
+    removed_members: Vec<(String, String)>,
+    on_put: Option<Box<dyn FnMut()>>,
+}
+
+impl FakePersistence {
+    fn new(put_outcome: PutOutcome, add_outcome: AddOutcome) -> Self {
+        Self {
+            put_outcome,
+            add_outcome,
+            put_keys: Vec::new(),
+            put_ttls: Vec::new(),
+            add_keys: Vec::new(),
+            add_ttls: Vec::new(),
+            deleted_keys: Vec::new(),
+            removed_members: Vec::new(),
+            on_put: None,
+        }
+    }
+}
+
+impl BrowserEphemeralPersistence for FakePersistence {
+    fn put_ephemeral(&mut self, key: &str, _value: &str, ttl: Duration) -> Result<bool, ()> {
+        self.put_keys.push(key.to_string());
+        self.put_ttls.push(ttl);
+        if let Some(on_put) = self.on_put.as_mut() {
+            on_put();
+        }
+        match self.put_outcome {
+            PutOutcome::Stored => Ok(true),
+            PutOutcome::NotStored => Ok(false),
+            PutOutcome::Error => Err(()),
+        }
+    }
+
+    fn add_ephemeral_member(&mut self, key: &str, _member: &str, ttl: Duration) -> Result<(), ()> {
+        self.add_keys.push(key.to_string());
+        self.add_ttls.push(ttl);
+        match self.add_outcome {
+            AddOutcome::Stored => Ok(()),
+            AddOutcome::Error => Err(()),
+        }
+    }
+
+    fn delete_ephemeral(&mut self, key: &str) -> Result<(), ()> {
+        self.deleted_keys.push(key.to_string());
+        Ok(())
+    }
+
+    fn remove_ephemeral_member(&mut self, key: &str, member: &str) -> Result<(), ()> {
+        self.removed_members
+            .push((key.to_string(), member.to_string()));
+        Ok(())
+    }
+}
+
+fn transaction(nonce: &str, expires_at_unix_ms: u64) -> RuntimeGatewayBrowserTransaction {
+    RuntimeGatewayBrowserTransaction {
+        nonce: nonce.to_string(),
+        code_verifier: format!("verifier-{nonce}"),
+        expires_at_unix_ms,
+    }
+}
+
+fn session(name: &str, expires_at_unix_ms: u64) -> RuntimeGatewayBrowserSession {
+    RuntimeGatewayBrowserSession {
+        protected_id_token: format!("protected-{name}"),
+        csrf_digest: [0; 32],
+        logout_keys: vec![format!("logout-{name}")],
+        expires_at_unix_ms,
+    }
+}
+
+#[test]
+fn transaction_persistence_failure_restores_prior_state() {
+    for outcome in [PutOutcome::NotStored, PutOutcome::Error] {
+        let state = RuntimeGatewayBrowserState::default();
+        let previous = Arc::new(transaction("previous", 100));
+        state
+            .transactions
+            .lock()
+            .unwrap()
+            .insert("state".to_string(), Arc::clone(&previous));
+        let mut persistence = FakePersistence::new(outcome, AddOutcome::Stored);
+
+        let result = browser_store_transaction_with_persistence(
+            &state,
+            "state".to_string(),
+            transaction("replacement", 100),
+            10,
+            Some(&mut persistence),
+        );
+
+        assert!(result.is_err());
+        let transactions = state.transactions.lock().unwrap();
+        assert!(
+            transactions
+                .get("state")
+                .is_some_and(|current| Arc::ptr_eq(current, &previous))
+        );
+        assert_eq!(
+            persistence.put_ttls,
+            vec![Duration::from_millis(BROWSER_TRANSACTION_TTL_MS)]
+        );
+    }
+}
+
+#[test]
+fn session_persistence_failure_restores_prior_state() {
+    for outcome in [PutOutcome::NotStored, PutOutcome::Error] {
+        let state = RuntimeGatewayBrowserState::default();
+        let previous = Arc::new(session("previous", 100));
+        state
+            .sessions
+            .lock()
+            .unwrap()
+            .insert("session".to_string(), Arc::clone(&previous));
+        let mut persistence = FakePersistence::new(outcome, AddOutcome::Stored);
+
+        let result = browser_store_session_with_persistence(
+            &state,
+            "session".to_string(),
+            session("replacement", 100),
+            10,
+            Some(&mut persistence),
+        );
+
+        assert!(result.is_err());
+        let sessions = state.sessions.lock().unwrap();
+        assert!(
+            sessions
+                .get("session")
+                .is_some_and(|current| Arc::ptr_eq(current, &previous))
+        );
+        assert_eq!(
+            persistence.put_ttls,
+            vec![Duration::from_millis(BROWSER_SESSION_TTL_MS)]
+        );
+    }
+}
+
+#[test]
+fn session_persistence_failure_restores_evicted_entry() {
+    for outcome in [PutOutcome::NotStored, PutOutcome::Error] {
+        let state = RuntimeGatewayBrowserState::default();
+        let oldest = Arc::new(session("oldest", 100));
+        let mut sessions = state.sessions.lock().unwrap();
+        sessions.insert("oldest".to_string(), Arc::clone(&oldest));
+        for index in 1..MAX_BROWSER_SESSIONS {
+            sessions.insert(
+                format!("session-{index}"),
+                Arc::new(session(&format!("session-{index}"), 100 + index as u64)),
+            );
+        }
+        drop(sessions);
+        let mut persistence = FakePersistence::new(outcome, AddOutcome::Stored);
+
+        let result = browser_store_session_with_persistence(
+            &state,
+            "provisional".to_string(),
+            session("provisional", 10_000),
+            10,
+            Some(&mut persistence),
+        );
+
+        assert!(result.is_err());
+        let sessions = state.sessions.lock().unwrap();
+        assert_eq!(sessions.len(), MAX_BROWSER_SESSIONS);
+        assert!(
+            sessions
+                .get("oldest")
+                .is_some_and(|current| Arc::ptr_eq(current, &oldest))
+        );
+        assert!(!sessions.contains_key("provisional"));
+    }
+}
+
+#[test]
+fn persistence_failure_preserves_replacement_owner() {
+    let state = RuntimeGatewayBrowserState::default();
+    let sessions = Arc::clone(&state.sessions);
+    let replacement = Arc::new(session("replacement", 100));
+    let replacement_for_hook = Arc::clone(&replacement);
+    let mut persistence = FakePersistence::new(PutOutcome::Error, AddOutcome::Stored);
+    persistence.on_put = Some(Box::new(move || {
+        sessions
+            .lock()
+            .unwrap()
+            .insert("session".to_string(), Arc::clone(&replacement_for_hook));
+    }));
+
+    let result = browser_store_session_with_persistence(
+        &state,
+        "session".to_string(),
+        session("provisional", 100),
+        10,
+        Some(&mut persistence),
+    );
+
+    assert!(result.is_err());
+    assert!(
+        state
+            .sessions
+            .lock()
+            .unwrap()
+            .get("session")
+            .is_some_and(|current| Arc::ptr_eq(current, &replacement))
+    );
+}
+
+#[test]
+fn persistence_failure_preserves_evicted_replacement_owner() {
+    let state = RuntimeGatewayBrowserState::default();
+    let oldest = Arc::new(session("oldest", 100));
+    let replacement = Arc::new(session("replacement", 100));
+    let replacement_for_hook = Arc::clone(&replacement);
+    let mut sessions = state.sessions.lock().unwrap();
+    sessions.insert("oldest".to_string(), Arc::clone(&oldest));
+    for index in 1..MAX_BROWSER_SESSIONS {
+        sessions.insert(
+            format!("session-{index}"),
+            Arc::new(session(&format!("session-{index}"), 100 + index as u64)),
+        );
+    }
+    drop(sessions);
+    let sessions = Arc::clone(&state.sessions);
+    let mut persistence = FakePersistence::new(PutOutcome::Error, AddOutcome::Stored);
+    persistence.on_put = Some(Box::new(move || {
+        sessions
+            .lock()
+            .unwrap()
+            .insert("oldest".to_string(), Arc::clone(&replacement_for_hook));
+    }));
+
+    let result = browser_store_session_with_persistence(
+        &state,
+        "provisional".to_string(),
+        session("provisional", 10_000),
+        10,
+        Some(&mut persistence),
+    );
+
+    assert!(result.is_err());
+    assert!(
+        state
+            .sessions
+            .lock()
+            .unwrap()
+            .get("oldest")
+            .is_some_and(|current| Arc::ptr_eq(current, &replacement))
+    );
+}
+
+#[test]
+fn session_persistence_failure_does_not_restore_concurrently_deleted_evicted_entry() {
+    for outcome in [PutOutcome::NotStored, PutOutcome::Error] {
+        for recreate in [false, true] {
+            let state = RuntimeGatewayBrowserState::default();
+            let oldest = Arc::new(session("oldest", 100));
+            let mut sessions = state.sessions.lock().unwrap();
+            sessions.insert("oldest".to_string(), Arc::clone(&oldest));
+            for index in 1..MAX_BROWSER_SESSIONS {
+                sessions.insert(
+                    format!("session-{index}"),
+                    Arc::new(session(&format!("session-{index}"), 100 + index as u64)),
+                );
+            }
+            drop(sessions);
+
+            let recreated = Arc::new(session("recreated", 20_000));
+            let recreated_for_hook = Arc::clone(&recreated);
+            let state_for_hook = state.clone();
+            let mut persistence = FakePersistence::new(outcome, AddOutcome::Stored);
+            persistence.on_put = Some(Box::new(move || {
+                let _ = mark_session_mutation(&state_for_hook, "oldest");
+                if recreate {
+                    state_for_hook
+                        .sessions
+                        .lock()
+                        .unwrap()
+                        .insert("oldest".to_string(), Arc::clone(&recreated_for_hook));
+                }
+            }));
+
+            let result = browser_store_session_with_persistence(
+                &state,
+                "provisional".to_string(),
+                session("provisional", 10_000),
+                10,
+                Some(&mut persistence),
+            );
+
+            assert!(result.is_err());
+            let sessions = state.sessions.lock().unwrap();
+            assert!(!sessions.contains_key("provisional"));
+            assert!(
+                sessions
+                    .values()
+                    .all(|current| !Arc::ptr_eq(current, &oldest))
+            );
+            if recreate {
+                assert_eq!(sessions.len(), MAX_BROWSER_SESSIONS);
+                assert!(
+                    sessions
+                        .get("oldest")
+                        .is_some_and(|current| Arc::ptr_eq(current, &recreated))
+                );
+            } else {
+                assert_eq!(sessions.len(), MAX_BROWSER_SESSIONS - 1);
+                assert!(!sessions.contains_key("oldest"));
+            }
+        }
+    }
+}
+
+#[test]
+fn session_index_failure_cleans_remote_state_and_rolls_back_local_state() {
+    let state = RuntimeGatewayBrowserState::default();
+    let mut persistence = FakePersistence::new(PutOutcome::Stored, AddOutcome::Error);
+
+    let result = browser_store_session_with_persistence(
+        &state,
+        "session".to_string(),
+        session("session", 100),
+        10,
+        Some(&mut persistence),
+    );
+
+    assert!(result.is_err());
+    assert!(!state.sessions.lock().unwrap().contains_key("session"));
+    assert_eq!(
+        persistence.deleted_keys,
+        vec![format!("{SESSION_KEY_PREFIX}session")]
+    );
+    assert_eq!(
+        persistence.removed_members,
+        vec![("logout-session".to_string(), "session".to_string())]
+    );
+    assert_eq!(
+        persistence.add_ttls,
+        vec![Duration::from_millis(BROWSER_SESSION_TTL_MS)]
+    );
+}
+
+#[test]
+fn browser_shadow_expiry_capacity_and_ttl_contracts_match() {
+    let transactions = RuntimeGatewayBrowserState::default();
+    transactions.transactions.lock().unwrap().extend([
+        ("expired".to_string(), Arc::new(transaction("expired", 10))),
+        ("live".to_string(), Arc::new(transaction("live", 20))),
+    ]);
+    let mut transaction_persistence = FakePersistence::new(PutOutcome::Stored, AddOutcome::Stored);
+    browser_store_transaction_with_persistence(
+        &transactions,
+        "new".to_string(),
+        transaction("new", 30),
+        15,
+        Some(&mut transaction_persistence),
+    )
+    .ok()
+    .unwrap();
+    let transaction_entries = transactions.transactions.lock().unwrap();
+    assert!(!transaction_entries.contains_key("expired"));
+    assert!(transaction_entries.contains_key("live"));
+    assert_eq!(
+        transaction_persistence.put_ttls,
+        vec![Duration::from_millis(BROWSER_TRANSACTION_TTL_MS)]
+    );
+
+    let sessions = RuntimeGatewayBrowserState::default();
+    sessions.sessions.lock().unwrap().extend([
+        ("expired".to_string(), Arc::new(session("expired", 10))),
+        ("live".to_string(), Arc::new(session("live", 20))),
+    ]);
+    let mut session_persistence = FakePersistence::new(PutOutcome::Stored, AddOutcome::Stored);
+    browser_store_session_with_persistence(
+        &sessions,
+        "new".to_string(),
+        session("new", 30),
+        15,
+        Some(&mut session_persistence),
+    )
+    .ok()
+    .unwrap();
+    let session_entries = sessions.sessions.lock().unwrap();
+    assert!(!session_entries.contains_key("expired"));
+    assert!(session_entries.contains_key("live"));
+    assert_eq!(
+        session_persistence.put_ttls,
+        vec![Duration::from_millis(BROWSER_SESSION_TTL_MS)]
+    );
+    assert_eq!(
+        session_persistence.add_ttls,
+        vec![Duration::from_millis(BROWSER_SESSION_TTL_MS)]
+    );
+
+    let full_transactions = RuntimeGatewayBrowserState::default();
+    full_transactions
+        .transactions
+        .lock()
+        .unwrap()
+        .extend((0..MAX_BROWSER_TRANSACTIONS).map(|index| {
+            (
+                format!("state-{index}"),
+                Arc::new(transaction(&format!("nonce-{index}"), 100)),
+            )
+        }));
+    let mut rejected_persistence = FakePersistence::new(PutOutcome::Stored, AddOutcome::Stored);
+    assert!(
+        browser_store_transaction_with_persistence(
+            &full_transactions,
+            "rejected".to_string(),
+            transaction("rejected", 100),
+            10,
+            Some(&mut rejected_persistence),
+        )
+        .is_err()
+    );
+    assert!(rejected_persistence.put_keys.is_empty());
 }

--- a/scripts/ci/mojo-production-share.test.mjs
+++ b/scripts/ci/mojo-production-share.test.mjs
@@ -215,8 +215,8 @@ test("canonical report exposes separate statuses and --check enforces only floor
   const report = JSON.parse(runShare("--json"));
   assert.equal(report.current_prodex_version, await readCargoVersion());
   assert.equal(report.final.broad_mojo_production_loc, 26_420);
-  assert.equal(report.final.broad_total_production_loc, 374_867);
-  assert.equal(report.final.broad_mojo_percent, 7.047832964758167);
+  assert.equal(report.final.broad_total_production_loc, 375_101);
+  assert.equal(report.final.broad_mojo_percent, 7.0434363011562215);
   assert.equal(report.release_floor_percent, 7);
   assert.equal(report.release_floor_met, true);
   assert.equal(report.release_floor_status, "PASS");


### PR DESCRIPTION
Main-based B0-049 port from the exact reviewed recovery behavior.\n\nBase: be3545e11e5dc99744d322f5f6a609d507d8c0dd\nHead: efd5ba9fe34a140ee331347c2767cbfea3ce0d75\nSource provenance: ca5d6c9a0ad37b3ea07e8ea6c666174e376441a6, independently reviewed for the equivalent owner behavior on its original base.\n\nThis candidate adapts the generation/Arc ownership fence to the current main browser owner, preserves the existing Redis remote cleanup semantics, adds deterministic offline rollback tests, and refreshes only canonical Mojo fixture assertions. Local browser 11/11, cargo check, Clippy -D warnings, fmt, Node 13/13, canonical Mojo guard, and diff checks pass. Fresh exact-main CI is required; no protected-main mutation has occurred.