### PR TITLE
fix(presidio): reject inverted blocking ranges on main

### DIFF
--- a/crates/prodex-presidio/src/blocking_http.rs
+++ b/crates/prodex-presidio/src/blocking_http.rs
@@ -109,8 +109,13 @@ fn presidio_analyze_with_limit(
             presidio_redacted_message(body.trim())
         );
     }
-    read_presidio_json_response(response, max_response_bytes)
-        .context("failed to parse Presidio Analyzer response")
+    let results =
+        read_presidio_json_response::<Vec<PresidioAnalyzerResult>>(response, max_response_bytes)
+            .context("failed to parse Presidio Analyzer response")?;
+    if results.iter().any(|result| result.start > result.end) {
+        anyhow::bail!("Presidio Analyzer returned an invalid finding range");
+    }
+    Ok(results)
 }
 
 pub fn presidio_anonymize(
@@ -259,6 +264,37 @@ mod tests {
         .to_string();
 
         assert!(error.contains("302"), "{error}");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn presidio_analyze_rejects_inverted_finding_range() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            let body = r#"[{"start":3,"end":1,"score":1.0,"entity_type":"PERSON"}]"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let error = presidio_analyze(
+            &presidio_http_client().unwrap(),
+            &format!("http://{address}"),
+            "synthetic-input",
+            "en",
+        )
+        .expect_err("inverted analyzer ranges must be rejected")
+        .to_string();
+
+        assert_eq!(error, "Presidio Analyzer returned an invalid finding range");
         server.join().unwrap();
     }
 

--- a/scripts/ci/mojo-production-share.test.mjs
+++ b/scripts/ci/mojo-production-share.test.mjs
@@ -215,8 +215,8 @@ test("canonical report exposes separate statuses and --check enforces only floor
   const report = JSON.parse(runShare("--json"));
   assert.equal(report.current_prodex_version, await readCargoVersion());
   assert.equal(report.final.broad_mojo_production_loc, 26_420);
-  assert.equal(report.final.broad_total_production_loc, 375_101);
-  assert.equal(report.final.broad_mojo_percent, 7.0434363011562215);
+  assert.equal(report.final.broad_total_production_loc, 375_106);
+  assert.equal(report.final.broad_mojo_percent, 7.043342415210634);
   assert.equal(report.release_floor_percent, 7);
   assert.equal(report.release_floor_met, true);
   assert.equal(report.release_floor_status, "PASS");


### PR DESCRIPTION
Current-main Presidio blocking-path correction.\n\nBase: efd5ba9fe34a140ee331347c2767cbfea3ce0d75\nHead: d6a49acf90c61db004fa6d3b073436aeff2899ea\n\nThe exact c076 regression test failed on efd5 before this change because blocking presidio_analyze accepted start=3,end=1. This commit validates Vec<PresidioAnalyzerResult> and rejects inverted ranges before downstream use. Targeted 1/1, full prodex-presidio 11/11, Clippy -D warnings, fmt and diff checks pass. No live service or credentials used.